### PR TITLE
feat: human + machine outputs (md/json/yaml)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pymupdf>=1.24",
     "pydantic>=2.0",
     "InquirerPy>=0.3",
+    "PyYAML>=6.0",
 ]
 
 [project.urls]

--- a/skills/wst-cli/SKILL.md
+++ b/skills/wst-cli/SKILL.md
@@ -1,6 +1,68 @@
-# Skill: wst CLI
+# Skill: biblioteca-digital-wan-shi-tong-wst-cli (wst)
 
 CLI para organizar PDFs/libros con metadata generada por IA, búsqueda full‑text (SQLite FTS) y backups (iCloud/S3).
+
+## Casos de uso (lo que la IA debe hacer)
+
+### Llevar un libro a mi iCloud / iPad
+
+Objetivo: dado un título aproximado, encontrar el libro en la biblioteca y subirlo a iCloud (para que aparezca en iPad).
+
+Flujo recomendado:
+1) Buscar el libro por texto.
+2) Elegir el resultado correcto por **ID**.
+3) Ejecutar backup a iCloud por ID.
+
+Ejemplos:
+
+```bash
+wst search "story teller tactics" --format json
+wst show 12 --format json
+wst backup icloud 12 --format json
+```
+
+Instrucciones humanas típicas:
+- “lleva de mi biblioteca a mi ipad el libro de *Story Teller Tactics*”
+- “pásame a iCloud el libro *Cosmos*”
+
+### Ingestar una carpeta a mi biblioteca
+
+Objetivo: ingestarlo todo desde una carpeta que te indique (por ejemplo Escritorio) y meterlo en la biblioteca.
+
+Ejemplos:
+
+```bash
+wst ingest ~/Desktop --format json
+wst ingest ~/Desktop --ocr --ocr-language spa --format json
+```
+
+Instrucciones humanas típicas:
+- “lleva a mi biblioteca los libros que dejé en mi escritorio”
+- “ingesta la carpeta Descargas a mi biblioteca”
+
+### Corregir la info de un libro con OCR
+
+Objetivo: cuando un PDF escaneado no tiene texto, correr OCR y luego enriquecer/arreglar metadata.
+
+Flujo recomendado (seguro):
+1) OCR del archivo (si aplica).
+2) Identificar el documento en la biblioteca.
+3) Enriquecer metadata en el documento (o en lote con `fix`).
+
+Ejemplos:
+
+```bash
+# 1) OCR al archivo antes de ingestar (si aún no está en la biblioteca)
+wst ingest ~/Desktop/scan.pdf --ocr --ocr-language spa --format json
+
+# 2) Si ya está en la biblioteca, ubícalo por búsqueda y enriquece
+wst search "topologia" --format json
+wst edit 12 --enrich -y --format json
+```
+
+Instrucciones humanas típicas:
+- “corrige la info del libro X y si es escaneado pásale OCR”
+- “¿qué libro de topología tengo en mi biblioteca?”
 
 ## Instalación
 
@@ -57,6 +119,14 @@ wst list --type paper --sort year --format yaml
 ```bash
 wst search "machine learning"
 wst search "cosmos" --author "Sagan" --format json
+```
+
+Ejemplos orientados a preguntas humanas:
+
+```bash
+# “¿Qué libro de topología tengo en mi biblioteca?”
+wst search "topologia" --format json
+wst search "topology" --format json
 ```
 
 ### Mostrar metadata completa
@@ -147,6 +217,7 @@ wst backup icloud "Cosmos" --format yaml
 ## Reglas para IA (operación segura y reproducible)
 
 - Preferir **IDs** (`wst list`/`wst search`) para seleccionar documentos en vez de títulos aproximados.
+- Para instrucciones humanas ambiguas (“llévalo al iPad”), asumir que significa **`backup icloud`**.
 - En `--format md|json|yaml`, evitar cualquier comando que requiera prompts; usar `-y`, `--dry-run`, `--set` según corresponda.
 - Para acciones potencialmente destructivas:
   - usar `--dry-run` primero cuando exista

--- a/skills/wst-cli/SKILL.md
+++ b/skills/wst-cli/SKILL.md
@@ -1,0 +1,155 @@
+# Skill: wst CLI
+
+CLI para organizar PDFs/libros con metadata generada por IA, búsqueda full‑text (SQLite FTS) y backups (iCloud/S3).
+
+## Instalación
+
+### pipx (recomendado)
+
+```bash
+pipx install wst-library
+```
+
+### pip
+
+```bash
+pip install wst-library
+```
+
+### Extras opcionales
+
+- OCR:
+
+```bash
+pip install "wst-library[ocr]"
+```
+
+- S3 backup:
+
+```bash
+pip install "wst-library[s3]"
+```
+
+## Output para humanos vs máquinas
+
+Todos los comandos aceptan `--format human|md|json|yaml` (default `human`).
+
+- `--format human`: pensado para terminal (tablas, mensajes, progreso).
+- `--format md|json|yaml`: pensado para automatización.
+  - No hay prompts interactivos.
+  - La salida es determinística (sin barras de progreso).
+  - El payload es estable:
+    - Éxito: `{ "ok": true, "data": ... }`
+    - Error: `{ "ok": false, "error": { "code": ..., "message": ..., "details": ... } }`
+
+## Comandos principales (no interactivos)
+
+### Listar
+
+```bash
+wst list
+wst list --format json
+wst list --type paper --sort year --format yaml
+```
+
+### Buscar
+
+```bash
+wst search "machine learning"
+wst search "cosmos" --author "Sagan" --format json
+```
+
+### Mostrar metadata completa
+
+```bash
+wst show 3
+wst show 3 --format yaml
+```
+
+### Ingesta
+
+```bash
+wst ingest
+wst ingest ~/Downloads/book.pdf
+wst ingest --ocr --ocr-language spa
+wst ingest --format json
+```
+
+Notas:
+- `--confirm` es interactivo (pregunta por archivo). Evitar en pipelines.
+- `-v/--verbose` imprime logs por archivo (útil para debugging humano).
+
+### OCR
+
+```bash
+wst ocr scan.pdf --format json
+wst ocr ~/scans -l spa+eng --format yaml
+```
+
+### Enriquecer metadata en lote
+
+```bash
+wst fix --dry-run --format json
+wst fix -y --format yaml
+```
+
+## Comandos interactivos (y alternativas scriptables)
+
+### `wst browse`
+
+- Interactivo:
+
+```bash
+wst browse
+```
+
+- Scriptable (sin prompts):
+
+```bash
+wst browse --id 3 --action view --format json
+wst browse --query "cosmos" --first --action view --format yaml
+wst browse --id 3 --action open --no-launch --format json
+wst browse --id 3 --action delete --dry-run --format md
+wst browse --id 3 --action delete -y --format json
+wst browse --id 3 --action edit --set title="New" --dry-run --format json
+wst browse --id 3 --action edit --set title="New" -y --format json
+```
+
+### `wst edit`
+
+- Interactivo por defecto:
+
+```bash
+wst edit 3
+```
+
+- No interactivo:
+
+```bash
+wst edit 3 --set title="New title" --dry-run --format json
+wst edit 3 --set title="New title" -y --format yaml
+wst edit 3 --enrich -y --format json
+```
+
+## Backup (consideraciones)
+
+En general, el setup/configuración puede requerir modo humano.
+
+```bash
+# S3 configure: interactivo
+wst backup s3 --configure --format human
+
+# Backup por ID/título (scriptable)
+wst backup s3 3 --format json
+wst backup icloud "Cosmos" --format yaml
+```
+
+## Reglas para IA (operación segura y reproducible)
+
+- Preferir **IDs** (`wst list`/`wst search`) para seleccionar documentos en vez de títulos aproximados.
+- En `--format md|json|yaml`, evitar cualquier comando que requiera prompts; usar `-y`, `--dry-run`, `--set` según corresponda.
+- Para acciones potencialmente destructivas:
+  - usar `--dry-run` primero cuando exista
+  - exigir `-y/--yes` para aplicar
+- Para `open/find` desde automatización, usar `--no-launch` para no abrir apps.
+

--- a/src/wst/ai.py
+++ b/src/wst/ai.py
@@ -93,7 +93,8 @@ metadata as a JSON object matching the schema below.
 
 IMPORTANT:
 - Keep ALL existing values unchanged — do not modify fields that already have values.
-- You MUST use web search to find missing fields. Do NOT guess or return null without searching first.
+- You MUST use web search to find missing fields.
+  Do NOT guess or return null without searching first.
 - For ISBN: search Google Books, Open Library, Amazon, or WorldCat. Try multiple queries:
   - Search by exact title and author
   - Try alternate titles (e.g. translated titles, original language titles)

--- a/src/wst/ai.py
+++ b/src/wst/ai.py
@@ -14,9 +14,7 @@ class AIBackend(ABC):
     ) -> DocumentMetadata: ...
 
     @abstractmethod
-    def enrich_metadata(
-        self, metadata: DocumentMetadata, text_sample: str
-    ) -> DocumentMetadata: ...
+    def enrich_metadata(self, metadata: DocumentMetadata, text_sample: str) -> DocumentMetadata: ...
 
 
 def _extract_json(text: str) -> dict:
@@ -36,9 +34,7 @@ def _normalize_enrich_result(data: dict) -> dict:
     return data
 
 
-def _build_ingest_prompt(
-    existing_meta: dict, text_sample: str, filename: str, schema: str
-) -> str:
+def _build_ingest_prompt(existing_meta: dict, text_sample: str, filename: str, schema: str) -> str:
     meta_str = json.dumps({k: v for k, v in existing_meta.items() if v}, indent=2)
     max_chars = 8000
     if len(text_sample) > max_chars:
@@ -74,13 +70,9 @@ No explanation, no markdown, just the raw JSON.
   Search for the book title and author to find this information."""
 
 
-def _build_enrich_prompt(
-    metadata: DocumentMetadata, text_sample: str, schema: str
-) -> str:
+def _build_enrich_prompt(metadata: DocumentMetadata, text_sample: str, schema: str) -> str:
     current = metadata.model_dump(mode="json")
-    current_str = json.dumps(
-        {k: v for k, v in current.items() if v is not None}, indent=2
-    )
+    current_str = json.dumps({k: v for k, v in current.items() if v is not None}, indent=2)
     missing = [k for k, v in current.items() if v is None]
 
     max_chars = 8000
@@ -131,9 +123,7 @@ class ClaudeCLIBackend(AIBackend):
         result = self._run_claude(prompt)
         return DocumentMetadata.model_validate(_extract_json(result))
 
-    def enrich_metadata(
-        self, metadata: DocumentMetadata, text_sample: str
-    ) -> DocumentMetadata:
+    def enrich_metadata(self, metadata: DocumentMetadata, text_sample: str) -> DocumentMetadata:
         schema = json.dumps(DocumentMetadata.model_json_schema())
         prompt = _build_enrich_prompt(metadata, text_sample, schema)
         result = self._run_claude(prompt)
@@ -178,9 +168,7 @@ class CodexCLIBackend(AIBackend):
         result = self._run_codex(prompt)
         return DocumentMetadata.model_validate(_extract_json(result))
 
-    def enrich_metadata(
-        self, metadata: DocumentMetadata, text_sample: str
-    ) -> DocumentMetadata:
+    def enrich_metadata(self, metadata: DocumentMetadata, text_sample: str) -> DocumentMetadata:
         schema = json.dumps(DocumentMetadata.model_json_schema())
         prompt = _build_enrich_prompt(metadata, text_sample, schema)
         result = self._run_codex(prompt)
@@ -188,9 +176,7 @@ class CodexCLIBackend(AIBackend):
         return DocumentMetadata.model_validate(data)
 
     def _run_codex(self, prompt: str) -> str:
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".txt", delete=False
-        ) as out_file:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as out_file:
             out_path = out_file.name
 
         result = subprocess.run(

--- a/src/wst/backup.py
+++ b/src/wst/backup.py
@@ -3,6 +3,7 @@ import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
 
+import click
 from InquirerPy import inquirer
 
 from wst.db import Database
@@ -36,7 +37,7 @@ class BackupProvider(ABC):
         ...
 
     @abstractmethod
-    def backup_all(self, library_path: Path) -> int:
+    def backup_all(self, library_path: Path, *, emit: bool = True) -> int:
         """Backup entire library. Returns number of files backed up."""
         ...
 
@@ -64,13 +65,13 @@ class ICloudProvider(BackupProvider):
         if not self.is_configured():
             system = platform.system()
             if system == "Darwin":
-                print("iCloud Drive not found.")
-                print("Enable it in System Settings > Apple ID > iCloud.")
+                click.echo("iCloud Drive not found.")
+                click.echo("Enable it in System Settings > Apple ID > iCloud.")
             elif system == "Windows":
-                print("iCloud Drive not found.")
-                print("Install iCloud for Windows from the Microsoft Store.")
+                click.echo("iCloud Drive not found.")
+                click.echo("Install iCloud for Windows from the Microsoft Store.")
             else:
-                print(f"iCloud Drive is not supported on {system}.")
+                click.echo(f"iCloud Drive is not supported on {system}.")
             return
 
         subfolder = (
@@ -85,30 +86,34 @@ class ICloudProvider(BackupProvider):
         self.subfolder = subfolder
         self.dest_root = self.icloud_base / subfolder
         self.dest_root.mkdir(parents=True, exist_ok=True)
-        print(f"Configured: {self.dest_root}")
+        click.echo(f"Configured: {self.dest_root}")
 
     def backup_file(self, source: Path, dest_relative: str) -> None:
         dest = self.dest_root / dest_relative
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(str(source), str(dest))
 
-    def backup_all(self, library_path: Path) -> int:
+    def backup_all(self, library_path: Path, *, emit: bool = True) -> int:
         from wst.document import is_supported
 
         count = 0
         for pdf in sorted(p for p in library_path.rglob("*") if p.is_file() and is_supported(p)):
             relative = str(pdf.relative_to(library_path))
-            print(f"  {relative}...", end=" ", flush=True)
+            if emit:
+                click.echo(f"  {relative}... ", nl=False)
             self.backup_file(pdf, relative)
-            print("done")
+            if emit:
+                click.echo("done")
             count += 1
 
         # Backup the database too
         db_path = library_path / "wst.db"
         if db_path.exists():
-            print("  wst.db...", end=" ", flush=True)
+            if emit:
+                click.echo("  wst.db... ", nl=False)
             self.backup_file(db_path, "wst.db")
-            print("done")
+            if emit:
+                click.echo("done")
 
         return count
 
@@ -134,7 +139,7 @@ class S3Provider(BackupProvider):
         try:
             import boto3
         except ImportError:
-            print(
+            click.echo(
                 "Error: S3 backup requires the 's3' extra. Install it with:\n"
                 "\n"
                 "  pip install wst-library[s3]\n"
@@ -166,20 +171,20 @@ class S3Provider(BackupProvider):
         try:
             import boto3  # noqa: F401
         except ImportError:
-            print(
+            click.echo(
                 "Error: S3 backup requires the 's3' extra. Install it with:\n"
                 "\n"
                 "  pip install wst-library[s3]\n"
             )
             return
 
-        print("\n--- S3 Backup Configuration ---")
-        print("Enter your S3 bucket credentials.")
-        print("These are stored locally in ~/wst/config.json\n")
+        click.echo("\n--- S3 Backup Configuration ---")
+        click.echo("Enter your S3 bucket credentials.")
+        click.echo("These are stored locally in ~/wst/config.json\n")
 
         bucket = inquirer.text(message="Bucket name:").execute().strip()
         if not bucket:
-            print("Bucket name is required.")
+            click.echo("Bucket name is required.")
             return
 
         region = (
@@ -227,7 +232,7 @@ class S3Provider(BackupProvider):
         )
 
         if not access_key_id or not secret_access_key:
-            print("Access Key ID and Secret Access Key are required.")
+            click.echo("Access Key ID and Secret Access Key are required.")
             return
 
         save_s3_config(
@@ -246,10 +251,10 @@ class S3Provider(BackupProvider):
         if client:
             try:
                 client.head_bucket(Bucket=bucket)
-                print(f"\nConfigured and verified: s3://{bucket}")
+                click.echo(f"\nConfigured and verified: s3://{bucket}")
             except Exception as e:
-                print(f"\nConfiguration saved, but connection test failed: {e}")
-                print("Check your credentials and bucket name.")
+                click.echo(f"\nConfiguration saved, but connection test failed: {e}")
+                click.echo("Check your credentials and bucket name.")
 
     def _key(self, dest_relative: str) -> str:
         cfg = self._get_config() or {}
@@ -266,7 +271,7 @@ class S3Provider(BackupProvider):
         key = self._key(dest_relative)
         client.upload_file(str(source), cfg["bucket"], key)
 
-    def backup_all(self, library_path: Path) -> int:
+    def backup_all(self, library_path: Path, *, emit: bool = True) -> int:
         from wst.document import is_supported
 
         client = self._get_client()
@@ -276,17 +281,21 @@ class S3Provider(BackupProvider):
         count = 0
         for f in sorted(p for p in library_path.rglob("*") if p.is_file() and is_supported(p)):
             relative = str(f.relative_to(library_path))
-            print(f"  {relative}...", end=" ", flush=True)
+            if emit:
+                click.echo(f"  {relative}... ", nl=False)
             self.backup_file(f, relative)
-            print("done")
+            if emit:
+                click.echo("done")
             count += 1
 
         # Backup the database too
         db_path = library_path / "wst.db"
         if db_path.exists():
-            print("  wst.db...", end=" ", flush=True)
+            if emit:
+                click.echo("  wst.db... ", nl=False)
             self.backup_file(db_path, "wst.db")
-            print("done")
+            if emit:
+                click.echo("done")
 
         return count
 
@@ -318,7 +327,7 @@ def run_backup_interactive(
 ) -> None:
     """Interactive backup flow: choose all or select a file."""
     if not provider.is_configured():
-        print(f"Provider '{provider.name}' is not configured.")
+        click.echo(f"Provider '{provider.name}' is not configured.")
         provider.configure()
         if not provider.is_configured():
             return
@@ -332,13 +341,13 @@ def run_backup_interactive(
     ).execute()
 
     if choice == "all":
-        print(f"\nBacking up to {provider.name}...")
-        count = provider.backup_all(library_path)
-        print(f"\n{count} file(s) backed up.")
+        click.echo(f"\nBacking up to {provider.name}...")
+        count = provider.backup_all(library_path, emit=True)
+        click.echo(f"\n{count} file(s) backed up.")
     else:
         entries = db.list_all()
         if not entries:
-            print("Library is empty.")
+            click.echo("Library is empty.")
             return
 
         choices = [{"name": "Cancel", "value": None}] + [
@@ -359,12 +368,12 @@ def run_backup_interactive(
 
         source = library_path / entry.file_path
         if not source.exists():
-            print(f"File not found: {source}")
+            click.echo(f"File not found: {source}")
             return
 
-        print(f"Backing up: {entry.file_path}...", end=" ", flush=True)
+        click.echo(f"Backing up: {entry.file_path}... ", nl=False)
         provider.backup_file(source, entry.file_path)
-        print("done")
+        click.echo("done")
 
 
 def run_backup_file(
@@ -372,10 +381,13 @@ def run_backup_file(
     db: Database,
     library_path: Path,
     identifier: str,
+    *,
+    emit: bool = True,
 ) -> None:
     """Backup a specific file by ID or title."""
     if not provider.is_configured():
-        print(f"Provider '{provider.name}' is not configured.")
+        if emit:
+            click.echo(f"Provider '{provider.name}' is not configured.")
         provider.configure()
         if not provider.is_configured():
             return
@@ -386,14 +398,30 @@ def run_backup_file(
     if entry is None:
         entry = db.get_by_title(identifier)
     if entry is None:
-        print(f"Document not found: {identifier}")
+        if emit:
+            click.echo(f"Document not found: {identifier}")
         return
 
     source = library_path / entry.file_path
     if not source.exists():
-        print(f"File not found: {source}")
+        if emit:
+            click.echo(f"File not found: {source}")
         return
 
-    print(f"Backing up: {entry.file_path}...", end=" ", flush=True)
+    if emit:
+        click.echo(f"Backing up: {entry.file_path}... ", nl=False)
     provider.backup_file(source, entry.file_path)
-    print("done")
+    if emit:
+        click.echo("done")
+
+
+def run_backup_all(
+    provider: BackupProvider,
+    library_path: Path,
+    *,
+    emit: bool = True,
+) -> dict:
+    if not provider.is_configured():
+        raise RuntimeError(f"Provider '{provider.name}' is not configured.")
+    count = provider.backup_all(library_path, emit=emit)
+    return {"provider": provider.name, "backed_up_files": count}

--- a/src/wst/browse.py
+++ b/src/wst/browse.py
@@ -325,7 +325,12 @@ def run_action(
     if action in {"open", "find"}:
         file_path = library_path / entry.file_path
         if not file_path.exists():
-            return {"action": action, "status": "failed", "reason": "file not found", "path": str(file_path)}
+            return {
+                "action": action,
+                "status": "failed",
+                "reason": "file not found",
+                "path": str(file_path),
+            }
         cmd: list[str]
         system = platform.system()
         if action == "open":
@@ -345,7 +350,13 @@ def run_action(
 
         if not no_launch:
             subprocess.Popen(cmd)
-        return {"action": action, "status": "ok", "path": entry.file_path, "command": cmd, "launched": (not no_launch)}
+        return {
+            "action": action,
+            "status": "ok",
+            "path": entry.file_path,
+            "command": cmd,
+            "launched": (not no_launch),
+        }
 
     if action == "delete":
         if not yes and not dry_run:
@@ -416,7 +427,11 @@ def run_action(
                 if not dry_run:
                     entry.file_path = new_dest
                     entry.filename = Path(new_dest).name
-                moved = {"from": old_path, "to": new_dest, "note": "old file missing; DB path updated only"}
+                moved = {
+                    "from": old_path,
+                    "to": new_dest,
+                    "note": "old file missing; DB path updated only",
+                }
 
         if not dry_run:
             db.update(entry)

--- a/src/wst/browse.py
+++ b/src/wst/browse.py
@@ -9,6 +9,10 @@ from wst.models import DocType, LibraryEntry
 from wst.storage import LocalStorage, build_dest_path
 
 
+class BrowseUsageError(ValueError):
+    pass
+
+
 def browse_library(db: Database, storage: LocalStorage, library_path: Path) -> None:
     """Interactive TUI for browsing and editing documents."""
     while True:
@@ -256,3 +260,175 @@ def _edit_doc_type(current: DocType) -> DocType:
         choices=choices,
         default=current,
     ).execute()
+
+
+def resolve_entry(
+    db: Database,
+    *,
+    doc_id: int | None = None,
+    title: str | None = None,
+    query: str | None = None,
+    select: int | None = None,
+    first: bool = False,
+) -> LibraryEntry:
+    if doc_id is not None:
+        entry = db.get(doc_id)
+        if entry is None:
+            raise BrowseUsageError(f"Document not found: {doc_id}")
+        return entry
+
+    if title is not None:
+        entry = db.get_by_title(title)
+        if entry is None:
+            raise BrowseUsageError(f"Document not found: {title}")
+        return entry
+
+    if query is not None:
+        results = db.search(query)
+        if not results:
+            raise BrowseUsageError("No results found.")
+        if len(results) == 1:
+            return results[0]
+
+        idx = 0
+        if first:
+            idx = 0
+        elif select is not None:
+            if select < 1 or select > len(results):
+                raise BrowseUsageError(f"--select must be between 1 and {len(results)}")
+            idx = select - 1
+        else:
+            raise BrowseUsageError(
+                f"Query returned {len(results)} results. Use --select N or --first."
+            )
+        return results[idx]
+
+    raise BrowseUsageError("No selection provided. Use --id, --title, or --query.")
+
+
+def run_action(
+    entry: LibraryEntry,
+    *,
+    action: str,
+    db: Database,
+    storage: LocalStorage,
+    library_path: Path,
+    yes: bool = False,
+    dry_run: bool = False,
+    no_launch: bool = False,
+    set_kv: dict[str, str] | None = None,
+) -> dict:
+    action = action.lower()
+    if action == "view":
+        return {"action": "view", "entry": entry}
+
+    if action in {"open", "find"}:
+        file_path = library_path / entry.file_path
+        if not file_path.exists():
+            return {"action": action, "status": "failed", "reason": "file not found", "path": str(file_path)}
+        cmd: list[str]
+        system = platform.system()
+        if action == "open":
+            if system == "Darwin":
+                cmd = ["open", str(file_path)]
+            elif system == "Windows":
+                cmd = ["cmd", "/c", "start", "", str(file_path)]
+            else:
+                cmd = ["xdg-open", str(file_path)]
+        else:
+            if system == "Darwin":
+                cmd = ["open", "-R", str(file_path)]
+            elif system == "Windows":
+                cmd = ["explorer", "/select,", str(file_path)]
+            else:
+                cmd = ["xdg-open", str(file_path.parent)]
+
+        if not no_launch:
+            subprocess.Popen(cmd)
+        return {"action": action, "status": "ok", "path": entry.file_path, "command": cmd, "launched": (not no_launch)}
+
+    if action == "delete":
+        if not yes and not dry_run:
+            raise BrowseUsageError("Delete requires --yes or --dry-run.")
+        file_path = library_path / entry.file_path
+        result = {"action": "delete", "id": entry.id, "path": entry.file_path, "dry_run": dry_run}
+        if dry_run:
+            return {**result, "status": "preview"}
+        db.delete(entry.id)
+        if file_path.exists():
+            file_path.unlink()
+            parent = file_path.parent
+            if parent != library_path and not any(parent.iterdir()):
+                parent.rmdir()
+        return {**result, "status": "deleted"}
+
+    if action == "edit":
+        if not set_kv:
+            raise BrowseUsageError("Edit requires --set key=value (repeatable).")
+        if not yes and not dry_run:
+            raise BrowseUsageError("Edit requires --yes or --dry-run.")
+        m = entry.metadata
+        before = m.model_dump()
+        for k, v in set_kv.items():
+            match k:
+                case "title":
+                    m.title = v
+                case "author":
+                    m.author = v
+                case "type" | "doc_type":
+                    m.doc_type = DocType(v)
+                case "year":
+                    m.year = int(v) if v else None
+                case "publisher":
+                    m.publisher = v or None
+                case "isbn":
+                    m.isbn = v or None
+                case "language":
+                    m.language = v or None
+                case "subject":
+                    m.subject = v or None
+                case "summary":
+                    m.summary = v or None
+                case "tags":
+                    m.tags = [t.strip() for t in v.split(",") if t.strip()] if v else []
+                case _:
+                    raise BrowseUsageError(f"Unknown metadata field for --set: {k}")
+
+        changes = []
+        after = m.model_dump()
+        for k in sorted(after.keys()):
+            if after[k] != before.get(k):
+                changes.append({"field": k, "before": before.get(k), "after": after[k]})
+
+        new_dest = build_dest_path(m)
+        old_path = entry.file_path
+        moved = None
+        if new_dest != old_path:
+            old_full = library_path / old_path
+            if old_full.exists():
+                if not dry_run:
+                    final = storage.store(old_full, new_dest)
+                    old_full.unlink()
+                    entry.file_path = final
+                    entry.filename = Path(final).name
+                moved = {"from": old_path, "to": new_dest}
+            else:
+                if not dry_run:
+                    entry.file_path = new_dest
+                    entry.filename = Path(new_dest).name
+                moved = {"from": old_path, "to": new_dest, "note": "old file missing; DB path updated only"}
+
+        if not dry_run:
+            db.update(entry)
+
+        return {
+            "action": "edit",
+            "applied": (not dry_run),
+            "dry_run": dry_run,
+            "id": entry.id,
+            "changes": changes,
+            "moved": moved,
+            "entry": entry,
+        }
+
+    raise BrowseUsageError(f"Unknown action: {action}. Allowed: view, open, find, edit, delete.")

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -8,7 +8,7 @@ from wst.ai import get_ai_backend
 from wst.config import WstConfig
 from wst.db import Database
 from wst.document import extract_doc_info, is_supported
-from wst.ingest import _find_documents, clean_inbox, format_metadata_display, ingest_files
+from wst.ingest import _find_documents, clean_inbox, ingest_files
 from wst.models import DocType, LibraryEntry
 from wst.storage import LocalStorage, build_dest_path
 
@@ -275,7 +275,8 @@ def backup(ctx: click.Context) -> None:
 
         raise WstError(
             "usage_error",
-            "Interactive backup requires --format human. Use `wst backup icloud|s3` with an identifier, or add non-interactive flags.",
+            "Interactive backup requires --format human. Use `wst backup icloud|s3` with an identifier, "
+            "or add non-interactive flags.",
             details={"hint": "Try: wst backup s3 3 --format json"},
             exit_code=2,
         )
@@ -406,7 +407,8 @@ def backup_s3(
 
                 raise WstError(
                     "requires_interactive",
-                    "Backup provider is not configured. Run `wst backup s3 --configure` in human mode first.",
+                    "Backup provider is not configured. "
+                    "Run `wst backup s3 --configure` in human mode first.",
                     details={"hint": "Try: wst backup s3 --configure --format human"},
                     exit_code=2,
                 )
@@ -423,9 +425,22 @@ def backup_s3(
 @cli.command()
 @click.option("--id", "doc_id", type=int, default=None, help="Select document by ID")
 @click.option("--title", default=None, help="Select document by exact title")
-@click.option("--query", default=None, help="Search query to select a document (uses full-text search)")
-@click.option("--select", type=int, default=None, help="When --query returns multiple results, pick N (1-based)")
-@click.option("--first", is_flag=True, help="When --query returns multiple results, pick the first match")
+@click.option(
+    "--query",
+    default=None,
+    help="Search query to select a document (uses full-text search)",
+)
+@click.option(
+    "--select",
+    type=int,
+    default=None,
+    help="When --query returns multiple results, pick N (1-based)",
+)
+@click.option(
+    "--first",
+    is_flag=True,
+    help="When --query returns multiple results, pick the first match",
+)
 @click.option(
     "--action",
     type=click.Choice(["view", "open", "find", "edit", "delete"], case_sensitive=False),
@@ -435,7 +450,11 @@ def backup_s3(
 @click.option("--set", "set_kv", multiple=True, help="For --action edit: key=value (repeatable)")
 @click.option("--yes", "-y", is_flag=True, help="Auto-accept (delete/edit) without prompting")
 @click.option("--dry-run", is_flag=True, help="Preview (delete/edit) without making changes")
-@click.option("--no-launch", is_flag=True, help="For open/find: don't launch apps; only output command/path")
+@click.option(
+    "--no-launch",
+    is_flag=True,
+    help="For open/find: don't launch apps; only output command/path",
+)
 @click.pass_context
 def browse(
     ctx: click.Context,
@@ -473,7 +492,20 @@ def browse(
     storage = LocalStorage(config.library_path)
 
     try:
-        if fmt == "human" and not any([doc_id, title, query, action, set_kv, yes, dry_run, no_launch, select, first]):
+        if fmt == "human" and not any(
+            [
+                doc_id,
+                title,
+                query,
+                action,
+                set_kv,
+                yes,
+                dry_run,
+                no_launch,
+                select,
+                first,
+            ]
+        ):
             browse_library(db, storage, config.library_path)
             return
 
@@ -877,12 +909,19 @@ def _coverage_bar(pct: float, width: int = 15) -> str:
 
 @cli.command()
 @click.argument("identifier")
-@click.option("--enrich", is_flag=True, help="Use AI to fill missing fields (ISBN, publisher, etc.)")
+@click.option(
+    "--enrich",
+    is_flag=True,
+    help="Use AI to fill missing fields (ISBN, publisher, etc.)",
+)
 @click.option(
     "--set",
     "set_kv",
     multiple=True,
-    help="Non-interactive update in key=value form (repeatable). Example: --set title=\"New\" --set year=2024",
+    help=(
+        "Non-interactive update in key=value form (repeatable). "
+        "Example: --set title=\"New\" --set year=2024"
+    ),
 )
 @click.option("--yes", "-y", is_flag=True, help="Auto-accept changes without prompting")
 @click.option(

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -13,15 +13,108 @@ from wst.models import DocType, LibraryEntry
 from wst.storage import LocalStorage, build_dest_path
 
 
-@click.group()
+class WstCli(click.Group):
+    def invoke(self, ctx: click.Context) -> object:  # type: ignore[override]
+        try:
+            return super().invoke(ctx)
+        except Exception as e:
+            fmt = None
+            try:
+                fmt = ctx.obj.get("format") if isinstance(ctx.obj, dict) else None
+            except Exception:
+                fmt = None
+
+            if fmt in {"md", "json", "yaml"}:
+                from wst.output import WstError, render_error
+
+                if isinstance(e, WstError):
+                    render_error(
+                        code=e.code,
+                        message=e.message,
+                        details=e.details,
+                        fmt=fmt,
+                    )
+                    raise SystemExit(e.exit_code)
+
+                if isinstance(e, click.UsageError):
+                    render_error(
+                        code="usage_error",
+                        message=e.format_message(),
+                        details={"hint": "See `wst --help` for usage."},
+                        fmt=fmt,
+                    )
+                    raise SystemExit(e.exit_code)
+
+                if isinstance(e, click.ClickException):
+                    render_error(
+                        code="click_error",
+                        message=e.format_message(),
+                        details=None,
+                        fmt=fmt,
+                    )
+                    raise SystemExit(e.exit_code)
+
+                if isinstance(e, SystemExit):
+                    render_error(
+                        code="system_exit",
+                        message="Command failed.",
+                        details={"exit_code": e.code},
+                        fmt=fmt,
+                    )
+                    raise
+
+                render_error(
+                    code="unexpected_error",
+                    message=str(e) or e.__class__.__name__,
+                    details=None,
+                    fmt=fmt,
+                )
+                raise SystemExit(1)
+
+            raise
+
+
+@click.group(cls=WstCli)
 @click.option("--backend", "-b", default=None,
               type=click.Choice(["claude", "codex"], case_sensitive=False),
               help="AI backend to use (default: claude)")
 @click.option("--model", "-m", "ai_model", default=None,
               help="AI model to use (e.g. sonnet, opus, gpt-5.4)")
+@click.option(
+    "--format",
+    "output_format",
+    default="human",
+    type=click.Choice(["human", "md", "json", "yaml"], case_sensitive=False),
+    help="Output format: human (terminal), md, json, yaml (default: human)",
+)
 @click.pass_context
-def cli(ctx: click.Context, backend: str | None, ai_model: str | None) -> None:
-    """wst — organize your books and PDFs."""
+def cli(
+    ctx: click.Context,
+    backend: str | None,
+    ai_model: str | None,
+    output_format: str,
+) -> None:
+    """wst — organize your books and PDFs.
+
+    \b
+    Output formats:
+      - --format human  : terminal-friendly output (default)
+      - --format md     : markdown (machine-friendly, pasteable)
+      - --format json   : structured output for scripts
+      - --format yaml   : structured output for configs/pipelines
+
+    \b
+    Notes:
+      - In machine formats (md/json/yaml), commands do not prompt for input.
+        Use explicit flags (e.g. -y/--yes, --set key=value) or the command will fail.
+
+    \b
+    Examples:
+      wst list
+      wst list --format json
+      wst show 3 --format yaml
+      wst browse --id 3 --action view --format md
+    """
     ctx.ensure_object(dict)
     config = WstConfig()
     if backend:
@@ -29,6 +122,7 @@ def cli(ctx: click.Context, backend: str | None, ai_model: str | None) -> None:
     if ai_model:
         config.ai_model = ai_model
     ctx.obj["config"] = config
+    ctx.obj["format"] = output_format.lower()
 
 
 @cli.command()
@@ -62,6 +156,11 @@ def ingest(
     (copies them to inbox for processing, without touching other inbox files).
 
     \b
+    Machine output:
+      - Use --format json|yaml|md for structured output.
+      - In machine formats, progress bars are disabled and output is emitted once at the end.
+
+    \b
     Examples:
         wst ingest                        # process and clean inbox
         wst ingest ~/Downloads/book.pdf   # ingest a single file
@@ -69,8 +168,10 @@ def ingest(
         wst ingest --keep-inbox           # process inbox without cleaning
         wst ingest -v                     # verbose per-file output
         wst ingest --ocr                  # OCR scanned PDFs before ingesting
+        wst ingest --format json          # structured output
     """
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     config.ensure_dirs()
 
     ai = get_ai_backend(config.ai_backend, config.ai_model)
@@ -78,6 +179,7 @@ def ingest(
     db = Database(config.db_path)
 
     try:
+        removed = 0
         if path is not None:
             copied_files = _copy_to_inbox(path, config.inbox_path)
             if not copied_files:
@@ -93,6 +195,7 @@ def ingest(
                 return
             files_to_process = _find_documents(config.inbox_path)
 
+        ocr_summary = None
         if ocr:
             from wst.ocr import ocr_files as run_ocr_batch
             from wst.ocr import require_ocr_dependencies
@@ -101,16 +204,22 @@ def ingest(
                 return
             pdfs = [f for f in files_to_process if f.suffix.lower() == ".pdf"]
             if pdfs:
-                click.echo("\n--- OCR pass ---")
-                run_ocr_batch(
+                if fmt == "human":
+                    click.echo("\n--- OCR pass ---")
+                ocr_summary = run_ocr_batch(
                     pdfs,
                     language=ocr_language,
                     verbose=verbose,
+                    emit=(fmt == "human"),
+                    progress=(fmt == "human"),
                 )
-                click.echo("")
+                if fmt == "human":
+                    click.echo("")
 
-        click.echo("--- Ingest pass ---")
-        ingest_files(
+        if fmt == "human":
+            click.echo("--- Ingest pass ---")
+
+        ingest_summary = ingest_files(
             files_to_process,
             ai,
             storage,
@@ -118,12 +227,26 @@ def ingest(
             auto_confirm=not confirm,
             reprocess=reprocess,
             verbose=verbose,
+            emit=(fmt == "human"),
+            progress=(fmt == "human"),
         )
 
         if path is None and not keep_inbox:
             removed = clean_inbox(config.inbox_path)
-            if removed > 0:
+            if fmt == "human" and removed > 0:
                 click.echo(f"Cleaned inbox: removed {removed} remaining file(s).")
+
+        if fmt != "human":
+            from wst.output import render_ok
+
+            render_ok(
+                {
+                    "ocr": ocr_summary,
+                    "ingest": ingest_summary,
+                    "cleaned_inbox_removed": removed,
+                },
+                fmt=fmt,
+            )
     finally:
         db.close()
 
@@ -131,13 +254,31 @@ def ingest(
 @cli.group(invoke_without_command=True)
 @click.pass_context
 def backup(ctx: click.Context) -> None:
-    """Backup library files to a cloud provider."""
+    """Backup library files to a cloud provider.
+
+    \b
+    This command is interactive by default.
+    For non-interactive scripting, use subcommands:
+      - wst backup icloud <ID|TITLE>
+      - wst backup s3 <ID|TITLE>
+    """
     from wst.backup import PROVIDERS, run_backup_interactive
 
     if ctx.invoked_subcommand is not None:
         return
 
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
+
+    if fmt != "human":
+        from wst.output import WstError
+
+        raise WstError(
+            "usage_error",
+            "Interactive backup requires --format human. Use `wst backup icloud|s3` with an identifier, or add non-interactive flags.",
+            details={"hint": "Try: wst backup s3 3 --format json"},
+            exit_code=2,
+        )
 
     # Interactive provider selection
     from InquirerPy import inquirer
@@ -164,12 +305,39 @@ def backup_icloud(ctx: click.Context, identifier: str | None) -> None:
     from wst.backup import ICloudProvider, run_backup_file, run_backup_interactive
 
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     provider = ICloudProvider()
     db = Database(config.db_path)
 
     try:
+        if fmt != "human" and not identifier:
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "Non-interactive backup requires an IDENTIFIER (ID or exact title).",
+                details={"hint": "Try: wst backup icloud 3 --format json"},
+                exit_code=2,
+            )
+
         if identifier:
-            run_backup_file(provider, db, config.library_path, identifier)
+            if fmt == "human":
+                run_backup_file(provider, db, config.library_path, identifier, emit=True)
+                return
+            if not provider.is_configured():
+                from wst.output import WstError
+
+                raise WstError(
+                    "requires_interactive",
+                    "Backup provider is not configured. Run interactive configuration first.",
+                    details={"hint": "Try: wst backup icloud --format human"},
+                    exit_code=2,
+                )
+            # Avoid stdout contamination from backup module in machine formats
+            run_backup_file(provider, db, config.library_path, identifier, emit=False)
+            from wst.output import render_ok
+
+            render_ok({"provider": "icloud", "identifier": identifier, "status": "ok"}, fmt=fmt)
         else:
             run_backup_interactive(provider, db, config.library_path)
     finally:
@@ -201,16 +369,51 @@ def backup_s3(
     from wst.backup import S3Provider, run_backup_file, run_backup_interactive
 
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     provider = S3Provider()
 
     if configure:
+        if fmt != "human":
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "S3 configuration is interactive. Use --format human.",
+                details={"hint": "Try: wst backup s3 --configure --format human"},
+                exit_code=2,
+            )
         provider.configure()
         return
 
     db = Database(config.db_path)
     try:
+        if fmt != "human" and not identifier:
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "Non-interactive backup requires an IDENTIFIER (ID or exact title).",
+                details={"hint": "Try: wst backup s3 3 --format json"},
+                exit_code=2,
+            )
+
         if identifier:
-            run_backup_file(provider, db, config.library_path, identifier)
+            if fmt == "human":
+                run_backup_file(provider, db, config.library_path, identifier, emit=True)
+                return
+            if not provider.is_configured():
+                from wst.output import WstError
+
+                raise WstError(
+                    "requires_interactive",
+                    "Backup provider is not configured. Run `wst backup s3 --configure` in human mode first.",
+                    details={"hint": "Try: wst backup s3 --configure --format human"},
+                    exit_code=2,
+                )
+            run_backup_file(provider, db, config.library_path, identifier, emit=False)
+            from wst.output import render_ok
+
+            render_ok({"provider": "s3", "identifier": identifier, "status": "ok"}, fmt=fmt)
         else:
             run_backup_interactive(provider, db, config.library_path)
     finally:
@@ -218,17 +421,117 @@ def backup_s3(
 
 
 @cli.command()
+@click.option("--id", "doc_id", type=int, default=None, help="Select document by ID")
+@click.option("--title", default=None, help="Select document by exact title")
+@click.option("--query", default=None, help="Search query to select a document (uses full-text search)")
+@click.option("--select", type=int, default=None, help="When --query returns multiple results, pick N (1-based)")
+@click.option("--first", is_flag=True, help="When --query returns multiple results, pick the first match")
+@click.option(
+    "--action",
+    type=click.Choice(["view", "open", "find", "edit", "delete"], case_sensitive=False),
+    default=None,
+    help="Non-interactive action to run on the selected document",
+)
+@click.option("--set", "set_kv", multiple=True, help="For --action edit: key=value (repeatable)")
+@click.option("--yes", "-y", is_flag=True, help="Auto-accept (delete/edit) without prompting")
+@click.option("--dry-run", is_flag=True, help="Preview (delete/edit) without making changes")
+@click.option("--no-launch", is_flag=True, help="For open/find: don't launch apps; only output command/path")
 @click.pass_context
-def browse(ctx: click.Context) -> None:
-    """Interactive browser for viewing and editing documents."""
-    from wst.browse import browse_library
+def browse(
+    ctx: click.Context,
+    doc_id: int | None,
+    title: str | None,
+    query: str | None,
+    select: int | None,
+    first: bool,
+    action: str | None,
+    set_kv: tuple[str, ...],
+    yes: bool,
+    dry_run: bool,
+    no_launch: bool,
+) -> None:
+    """Browse documents (interactive TUI or non-interactive actions).
+
+    \b
+    Interactive mode:
+      wst browse
+
+    \b
+    Non-interactive mode (scriptable):
+      wst browse --id 3 --action view --format json
+      wst browse --query "Cosmos" --first --action open --no-launch --format yaml
+      wst browse --id 3 --action delete --dry-run --format md
+      wst browse --id 3 --action delete -y --format json
+      wst browse --id 3 --action edit --set title="New" --dry-run --format json
+      wst browse --id 3 --action edit --set title="New" -y --format json
+    """
+    from wst.browse import BrowseUsageError, browse_library, resolve_entry, run_action
 
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
     storage = LocalStorage(config.library_path)
 
     try:
-        browse_library(db, storage, config.library_path)
+        if fmt == "human" and not any([doc_id, title, query, action, set_kv, yes, dry_run, no_launch, select, first]):
+            browse_library(db, storage, config.library_path)
+            return
+
+        if action is None:
+            # Non-interactive selection only is not useful; require an action.
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "Non-interactive browse requires --action plus a selector (--id/--title/--query).",
+                details={"hint": "Try: wst browse --id 3 --action view --format json"},
+                exit_code=2,
+            )
+
+        try:
+            entry = resolve_entry(
+                db,
+                doc_id=doc_id,
+                title=title,
+                query=query,
+                select=select,
+                first=first,
+            )
+        except BrowseUsageError as e:
+            if fmt == "human":
+                raise click.UsageError(str(e))
+            from wst.output import WstError
+
+            raise WstError("usage_error", str(e), exit_code=2)
+
+        set_dict = _parse_set_kv(set_kv) if set_kv else None
+        try:
+            result = run_action(
+                entry,
+                action=action,
+                db=db,
+                storage=storage,
+                library_path=config.library_path,
+                yes=yes,
+                dry_run=dry_run,
+                no_launch=no_launch,
+                set_kv=set_dict,
+            )
+        except BrowseUsageError as e:
+            if fmt == "human":
+                raise click.UsageError(str(e))
+            from wst.output import WstError
+
+            raise WstError("usage_error", str(e), exit_code=2)
+
+        if fmt == "human":
+            # Keep a minimal human output for non-interactive use
+            click.echo(result.get("status") or "ok")
+            return
+
+        from wst.output import render_ok
+
+        render_ok(result, fmt=fmt)
     finally:
         db.close()
 
@@ -256,7 +559,8 @@ def browse(ctx: click.Context) -> None:
     is_flag=True,
     help="Show detailed per-file processing logs",
 )
-def ocr(path: Path, language: str, force: bool, verbose: bool) -> None:
+@click.pass_context
+def ocr(ctx: click.Context, path: Path, language: str, force: bool, verbose: bool) -> None:
     """Run OCR on scanned PDFs to make them searchable.
 
     \b
@@ -271,8 +575,11 @@ def ocr(path: Path, language: str, force: bool, verbose: bool) -> None:
         wst ocr scan.pdf -l eng         # OCR in English
         wst ocr scan.pdf -l spa+eng     # OCR in Spanish and English
         wst ocr scan.pdf --force        # Force OCR even if text exists
+        wst ocr scan.pdf --format json  # structured output
     """
     from wst.ocr import ocr_files as run_ocr_batch
+
+    fmt: str = ctx.obj.get("format", "human")
 
     if path.is_file():
         if path.suffix.lower() != ".pdf":
@@ -288,7 +595,18 @@ def ocr(path: Path, language: str, force: bool, verbose: bool) -> None:
         click.echo("Path must be a file or directory.")
         return
 
-    run_ocr_batch(files, language=language, force=force, verbose=verbose)
+    summary = run_ocr_batch(
+        files,
+        language=language,
+        force=force,
+        verbose=verbose,
+        emit=(fmt == "human"),
+        progress=(fmt == "human"),
+    )
+    if fmt != "human":
+        from wst.output import render_ok
+
+        render_ok(summary, fmt=fmt)
 
 
 def _copy_to_inbox(source: Path, inbox: Path) -> list[Path]:
@@ -330,14 +648,25 @@ def search(
 ) -> None:
     """Search documents by title, author, tags, or subject."""
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
         results = db.search(query, doc_type=doc_type, author=author, subject=subject)
         if not results:
-            click.echo("No results found.")
+            if fmt == "human":
+                click.echo("No results found.")
+                return
+            from wst.output import render_ok
+
+            render_ok([], fmt=fmt)
             return
-        _print_table(results)
+        if fmt == "human":
+            _print_table(results)
+            return
+        from wst.output import render_ok
+
+        render_ok(results, fmt=fmt)
     finally:
         db.close()
 
@@ -356,14 +685,25 @@ def search(
 def list_cmd(ctx: click.Context, doc_type: str | None, sort_by: str) -> None:
     """List all documents in the library."""
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
         entries = db.list_all(doc_type=doc_type, sort_by=sort_by)
         if not entries:
-            click.echo("Library is empty.")
+            if fmt == "human":
+                click.echo("Library is empty.")
+                return
+            from wst.output import render_ok
+
+            render_ok([], fmt=fmt)
             return
-        _print_table(entries)
+        if fmt == "human":
+            _print_table(entries)
+            return
+        from wst.output import render_ok
+
+        render_ok(entries, fmt=fmt)
     finally:
         db.close()
 
@@ -374,13 +714,24 @@ def list_cmd(ctx: click.Context, doc_type: str | None, sort_by: str) -> None:
 def show(ctx: click.Context, identifier: str) -> None:
     """Show full metadata for a document (by ID or title)."""
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
         entry = _find_entry(db, identifier)
         if entry is None:
-            click.echo(f"Document not found: {identifier}")
-            raise SystemExit(1)
+            if fmt == "human":
+                click.echo(f"Document not found: {identifier}")
+                raise SystemExit(1)
+            from wst.output import WstError
+
+            raise WstError("not_found", f"Document not found: {identifier}", exit_code=1)
+
+        if fmt != "human":
+            from wst.output import render_ok
+
+            render_ok(entry, fmt=fmt)
+            return
 
         m = entry.metadata
         click.echo(f"ID:            {entry.id}")
@@ -421,12 +772,21 @@ def stats(ctx: click.Context, doc_type: str | None) -> None:
         wst stats --type textbook
     """
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
         entries = db.list_all(doc_type=doc_type)
         if not entries:
-            click.echo("Library is empty.")
+            if fmt == "human":
+                click.echo("Library is empty.")
+                return
+            from wst.output import render_ok
+
+            render_ok(
+                {"total": 0, "coverage_by_field": [], "breakdown_by_type": []},
+                fmt=fmt,
+            )
             return
 
         fields = ["title", "author", "year", "publisher", "isbn",
@@ -437,6 +797,39 @@ def stats(ctx: click.Context, doc_type: str | None) -> None:
         for e in entries:
             dt = e.metadata.doc_type.value
             by_type.setdefault(dt, []).append(e)
+
+        if fmt != "human":
+            coverage_by_field = []
+            for field in fields:
+                filled = sum(1 for e in entries if _field_filled(e, field))
+                missing = len(entries) - filled
+                pct = (filled / len(entries)) * 100
+                coverage_by_field.append(
+                    {"field": field, "filled": filled, "missing": missing, "coverage_pct": pct}
+                )
+
+            key_fields = ["isbn", "table_of_contents", "year", "publisher", "summary"]
+            breakdown_by_type = []
+            for dt in sorted(by_type):
+                group = by_type[dt]
+                total = len(group)
+                per = {}
+                for f in key_fields:
+                    n = sum(1 for e in group if _field_filled(e, f))
+                    per[f] = (n / total) * 100 if total else 0.0
+                breakdown_by_type.append({"type": dt, "total": total, **per})
+
+            from wst.output import render_ok
+
+            render_ok(
+                {
+                    "total": len(entries),
+                    "coverage_by_field": coverage_by_field,
+                    "breakdown_by_type": breakdown_by_type,
+                },
+                fmt=fmt,
+            )
+            return
 
         # Overall coverage per field
         click.echo(f"\nTotal documents: {len(entries)}\n")
@@ -485,9 +878,28 @@ def _coverage_bar(pct: float, width: int = 15) -> str:
 @cli.command()
 @click.argument("identifier")
 @click.option("--enrich", is_flag=True, help="Use AI to fill missing fields (ISBN, publisher, etc.)")
+@click.option(
+    "--set",
+    "set_kv",
+    multiple=True,
+    help="Non-interactive update in key=value form (repeatable). Example: --set title=\"New\" --set year=2024",
+)
+@click.option("--yes", "-y", is_flag=True, help="Auto-accept changes without prompting")
+@click.option(
+    "--move/--no-move",
+    default=True,
+    help="When metadata changes the destination path, move the file (default: move)",
+)
 @click.pass_context
-def edit(ctx: click.Context, identifier: str, enrich: bool) -> None:
-    """Interactively edit metadata for a document.
+def edit(
+    ctx: click.Context,
+    identifier: str,
+    enrich: bool,
+    set_kv: tuple[str, ...],
+    yes: bool,
+    move: bool,
+) -> None:
+    """Edit metadata for a document (interactive or non-interactive).
 
     \b
     Shows current values and lets you change any field.
@@ -499,26 +911,90 @@ def edit(ctx: click.Context, identifier: str, enrich: bool) -> None:
     publisher, year) using AI and web search.
 
     \b
+    Non-interactive mode:
+      - Use --set key=value (repeatable) and -y to apply.
+      - Without -y, the command performs a dry-run (no changes).
+
+    \b
     Examples:
         wst edit 1
         wst edit "Player's Handbook"
         wst edit 42 --enrich
+        wst edit 42 --enrich -y --format json
+        wst edit 42 --set title="New title" --dry-run --format yaml
+        wst edit 42 --set title="New title" -y --format json
     """
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
     storage = LocalStorage(config.library_path)
 
     try:
         entry = _find_entry(db, identifier)
         if entry is None:
-            click.echo(f"Document not found: {identifier}")
-            raise SystemExit(1)
+            if fmt == "human":
+                click.echo(f"Document not found: {identifier}")
+                raise SystemExit(1)
+            from wst.output import WstError
+
+            raise WstError("not_found", f"Document not found: {identifier}", exit_code=1)
 
         m = entry.metadata
 
         if enrich:
-            _enrich_entry(entry, config, db)
+            if fmt != "human" and not yes:
+                from wst.output import WstError
+
+                raise WstError(
+                    "usage_error",
+                    "Non-interactive enrich requires --yes (or use --format human).",
+                    details={"hint": "Try: wst edit <id> --enrich -y --format json"},
+                    exit_code=2,
+                )
+            _enrich_entry(entry, config, db, confirm=(fmt == "human" and not yes))
+            if fmt != "human":
+                from wst.output import render_ok
+
+                render_ok(entry, fmt=fmt)
             return
+
+        if set_kv:
+            updates = _parse_set_kv(set_kv)
+            updated_entry, changes = _apply_metadata_updates(
+                entry,
+                updates,
+                config=config,
+                db=db,
+                storage=storage,
+                move=move,
+                dry_run=not yes,
+                emit=(fmt == "human"),
+            )
+            if fmt == "human":
+                if not yes:
+                    click.echo("\nDry-run complete (use -y to apply).")
+                return
+            from wst.output import render_ok
+
+            render_ok(
+                {
+                    "applied": bool(yes),
+                    "changes": changes,
+                    "entry": updated_entry,
+                },
+                fmt=fmt,
+            )
+            return
+
+        if fmt != "human":
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "This command is interactive by default. Use --set key=value (and -y) for non-interactive mode.",
+                details={"hint": "Try: wst edit 1 --set title=\"...\" -y --format json"},
+                exit_code=2,
+            )
 
         click.echo(f"\nEditing: {m.title} (ID {entry.id})")
         click.echo("Press Enter to keep current value.\n")
@@ -562,7 +1038,11 @@ def edit(ctx: click.Context, identifier: str, enrich: bool) -> None:
 
 
 def _enrich_entry(
-    entry: LibraryEntry, config: WstConfig, db: Database
+    entry: LibraryEntry,
+    config: WstConfig,
+    db: Database,
+    *,
+    confirm: bool = True,
 ) -> None:
     m = entry.metadata
     missing = _get_missing_fields(m)
@@ -585,13 +1065,99 @@ def _enrich_entry(
         display = value if not isinstance(value, list) else ", ".join(value)
         click.echo(f"    {field}: {display}")
 
-    if not click.confirm("\n  Apply these changes?", default=True):
-        click.echo("  Skipped.")
-        return
+    if confirm:
+        if not click.confirm("\n  Apply these changes?", default=True):
+            click.echo("  Skipped.")
+            return
 
     entry.metadata = enriched
     db.update(entry)
     click.echo("  Updated successfully.")
+
+
+def _parse_set_kv(items: tuple[str, ...]) -> dict[str, str]:
+    updates: dict[str, str] = {}
+    for raw in items:
+        if "=" not in raw:
+            raise click.UsageError(f"Invalid --set value (expected key=value): {raw}")
+        k, v = raw.split("=", 1)
+        k = k.strip()
+        v = v.strip()
+        if not k:
+            raise click.UsageError(f"Invalid --set key: {raw}")
+        updates[k] = v
+    return updates
+
+
+def _apply_metadata_updates(
+    entry: LibraryEntry,
+    updates: dict[str, str],
+    *,
+    config: WstConfig,
+    db: Database,
+    storage: LocalStorage,
+    move: bool,
+    dry_run: bool,
+    emit: bool,
+) -> tuple[LibraryEntry, list[dict[str, object]]]:
+    m = entry.metadata
+    before = m.model_dump()
+
+    for k, v in updates.items():
+        match k:
+            case "title":
+                m.title = v
+            case "author":
+                m.author = v
+            case "type" | "doc_type":
+                m.doc_type = DocType(v)
+            case "year":
+                m.year = int(v) if v else None
+            case "publisher":
+                m.publisher = v or None
+            case "isbn":
+                m.isbn = v or None
+            case "language":
+                m.language = v or None
+            case "subject":
+                m.subject = v or None
+            case "summary":
+                m.summary = v or None
+            case "tags":
+                m.tags = [t.strip() for t in v.split(",") if t.strip()] if v else []
+            case _:
+                raise click.UsageError(f"Unknown metadata field for --set: {k}")
+
+    changes: list[dict[str, object]] = []
+    after = m.model_dump()
+    for k in sorted(after.keys()):
+        if after[k] != before.get(k):
+            changes.append({"field": k, "before": before.get(k), "after": after[k]})
+
+    new_dest = build_dest_path(m)
+    old_path = entry.file_path
+
+    if move and new_dest != old_path:
+        old_full = config.library_path / old_path
+        if old_full.exists():
+            if not dry_run:
+                final = storage.store(old_full, new_dest)
+                old_full.unlink()
+                entry.file_path = final
+                entry.filename = Path(final).name
+            if emit:
+                click.echo(f"\nMoved: {old_path} -> {new_dest}")
+        else:
+            if not dry_run:
+                entry.file_path = new_dest
+                entry.filename = Path(new_dest).name
+            if emit:
+                click.echo(f"\nWarning: old file not found at {old_path}, updated path in DB only.")
+
+    if not dry_run:
+        db.update(entry)
+
+    return entry, changes
 
 
 def _get_missing_fields(m: "DocumentMetadata") -> list[str]:
@@ -677,11 +1243,14 @@ def fix(ctx: click.Context, doc_type: str | None, field: tuple[str, ...], yes: b
         wst fix --field isbn --field toc
         wst fix --dry-run               # preview what needs fixing
         wst fix --type novel -y         # fix all novels, auto-accept
+        wst fix --dry-run --format json # preview as structured output
+        wst fix -y --format yaml        # run non-interactively
     """
     field_map = {"toc": "table_of_contents"}
     target_fields = [field_map.get(f, f) for f in field] if field else None
 
     config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
@@ -697,62 +1266,148 @@ def fix(ctx: click.Context, doc_type: str | None, field: tuple[str, ...], yes: b
                 to_fix.append((entry, missing))
 
         if not to_fix:
-            click.echo("All documents are complete. Nothing to fix.")
+            if fmt == "human":
+                click.echo("All documents are complete. Nothing to fix.")
+                return
+            from wst.output import render_ok
+
+            render_ok(
+                {
+                    "scanned": len(entries),
+                    "to_fix": 0,
+                    "fixed": 0,
+                    "skipped": 0,
+                    "failed": 0,
+                    "results": [],
+                },
+                fmt=fmt,
+            )
             return
 
-        click.echo(f"Found {len(to_fix)} document(s) with missing fields.\n")
+        if fmt != "human" and not dry_run and not yes:
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "Non-interactive fix requires -y/--yes (or use --dry-run).",
+                details={"hint": "Try: wst fix -y --format json"},
+                exit_code=2,
+            )
+
+        if fmt == "human":
+            click.echo(f"Found {len(to_fix)} document(s) with missing fields.\n")
 
         if dry_run:
-            click.echo(f"{'ID':>4}  {'Title':<40}  {'Type':<12}  Missing fields")
-            click.echo("-" * 90)
+            preview = []
             for entry, missing in to_fix:
                 m = entry.metadata
-                title = m.title[:38] + ".." if len(m.title) > 40 else m.title
-                click.echo(f"{entry.id:>4}  {title:<40}  {m.doc_type.value:<12}  {', '.join(missing)}")
+                preview.append(
+                    {
+                        "id": entry.id,
+                        "title": m.title,
+                        "type": m.doc_type.value,
+                        "missing_fields": missing,
+                    }
+                )
+            if fmt == "human":
+                click.echo(f"{'ID':>4}  {'Title':<40}  {'Type':<12}  Missing fields")
+                click.echo("-" * 90)
+                for entry, missing in to_fix:
+                    m = entry.metadata
+                    title = m.title[:38] + ".." if len(m.title) > 40 else m.title
+                    click.echo(
+                        f"{entry.id:>4}  {title:<40}  {m.doc_type.value:<12}  {', '.join(missing)}"
+                    )
+                return
+            from wst.output import render_ok
+
+            render_ok(
+                {
+                    "scanned": len(entries),
+                    "to_fix": len(to_fix),
+                    "preview": preview,
+                },
+                fmt=fmt,
+            )
             return
 
         fixed = 0
         failed = 0
         skipped = 0
         start = time.monotonic()
+        results = []
 
         for i, (entry, missing) in enumerate(to_fix, 1):
             m = entry.metadata
-            click.echo(f"\n[{i}/{len(to_fix)}] {m.title} (ID {entry.id})")
-            click.echo(f"  Missing: {', '.join(missing)}")
+            if fmt == "human":
+                click.echo(f"\n[{i}/{len(to_fix)}] {m.title} (ID {entry.id})")
+                click.echo(f"  Missing: {', '.join(missing)}")
 
             try:
                 changes, enriched = _run_enrich(entry, config)
             except Exception as e:
-                click.echo(f"  Error: {e}")
+                if fmt == "human":
+                    click.echo(f"  Error: {e}")
                 failed += 1
+                results.append(
+                    {
+                        "id": entry.id,
+                        "status": "failed",
+                        "error": str(e),
+                    }
+                )
                 continue
 
             if not changes:
-                click.echo("  No new information found.")
+                if fmt == "human":
+                    click.echo("  No new information found.")
                 skipped += 1
+                results.append({"id": entry.id, "status": "skipped", "changes": []})
                 continue
 
-            click.echo("  Found:")
-            for f_name, value in changes:
-                display = value if not isinstance(value, list) else ", ".join(value)
-                # Truncate long values like TOC for display
-                if isinstance(display, str) and len(display) > 80:
-                    display = display[:77] + "..."
-                click.echo(f"    {f_name}: {display}")
+            if fmt == "human":
+                click.echo("  Found:")
+                for f_name, value in changes:
+                    display = value if not isinstance(value, list) else ", ".join(value)
+                    # Truncate long values like TOC for display
+                    if isinstance(display, str) and len(display) > 80:
+                        display = display[:77] + "..."
+                    click.echo(f"    {f_name}: {display}")
 
-            if not yes:
+            if fmt == "human" and not yes:
                 if not click.confirm("  Apply?", default=True):
                     skipped += 1
+                    results.append({"id": entry.id, "status": "skipped", "changes": changes})
                     continue
 
             entry.metadata = enriched
             db.update(entry)
             fixed += 1
-            click.echo("  Updated.")
+            results.append({"id": entry.id, "status": "fixed", "changes": changes})
+            if fmt == "human":
+                click.echo("  Updated.")
 
         elapsed = time.monotonic() - start
-        click.echo(f"\nDone in {int(elapsed)}s: {fixed} fixed, {skipped} skipped, {failed} failed")
+        if fmt == "human":
+            click.echo(
+                f"\nDone in {int(elapsed)}s: {fixed} fixed, {skipped} skipped, {failed} failed"
+            )
+            return
+
+        from wst.output import render_ok
+
+        render_ok(
+            {
+                "scanned": len(entries),
+                "to_fix": len(to_fix),
+                "fixed": fixed,
+                "skipped": skipped,
+                "failed": failed,
+                "elapsed_seconds": elapsed,
+                "results": results,
+            },
+            fmt=fmt,
+        )
     finally:
         db.close()
 

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -75,11 +75,16 @@ class WstCli(click.Group):
 
 
 @click.group(cls=WstCli)
-@click.option("--backend", "-b", default=None,
-              type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="AI backend to use (default: claude)")
-@click.option("--model", "-m", "ai_model", default=None,
-              help="AI model to use (e.g. sonnet, opus, gpt-5.4)")
+@click.option(
+    "--backend",
+    "-b",
+    default=None,
+    type=click.Choice(["claude", "codex"], case_sensitive=False),
+    help="AI backend to use (default: claude)",
+)
+@click.option(
+    "--model", "-m", "ai_model", default=None, help="AI model to use (e.g. sonnet, opus, gpt-5.4)"
+)
 @click.option(
     "--format",
     "output_format",
@@ -789,9 +794,14 @@ def show(ctx: click.Context, identifier: str) -> None:
 
 
 @cli.command()
-@click.option("--type", "-t", "doc_type", default=None,
-              type=click.Choice([dt.value for dt in DocType], case_sensitive=False),
-              help="Filter by document type")
+@click.option(
+    "--type",
+    "-t",
+    "doc_type",
+    default=None,
+    type=click.Choice([dt.value for dt in DocType], case_sensitive=False),
+    help="Filter by document type",
+)
 @click.pass_context
 def stats(ctx: click.Context, doc_type: str | None) -> None:
     """Show metadata coverage statistics.
@@ -823,8 +833,18 @@ def stats(ctx: click.Context, doc_type: str | None) -> None:
             )
             return
 
-        fields = ["title", "author", "year", "publisher", "isbn",
-                   "language", "subject", "summary", "table_of_contents", "page_count"]
+        fields = [
+            "title",
+            "author",
+            "year",
+            "publisher",
+            "isbn",
+            "language",
+            "subject",
+            "summary",
+            "table_of_contents",
+            "page_count",
+        ]
 
         # Group by doc_type
         by_type: dict[str, list[LibraryEntry]] = {}
@@ -922,7 +942,7 @@ def _coverage_bar(pct: float, width: int = 15) -> str:
     multiple=True,
     help=(
         "Non-interactive update in key=value form (repeatable). "
-        "Example: --set title=\"New\" --set year=2024"
+        'Example: --set title="New" --set year=2024'
     ),
 )
 @click.option("--yes", "-y", is_flag=True, help="Auto-accept changes without prompting")
@@ -1036,7 +1056,7 @@ def edit(
                     "This command is interactive by default. "
                     "Use --set key=value (and -y) for non-interactive mode."
                 ),
-                details={"hint": "Try: wst edit 1 --set title=\"...\" -y --format json"},
+                details={"hint": 'Try: wst edit 1 --set title="..." -y --format json'},
                 exit_code=2,
             )
 
@@ -1208,9 +1228,7 @@ def _get_missing_fields(m) -> list[str]:
     return [k for k, v in m.model_dump().items() if v is None]
 
 
-def _run_enrich(
-    entry: LibraryEntry, config: WstConfig
-) -> tuple[list[tuple[str, object]], object]:
+def _run_enrich(entry: LibraryEntry, config: WstConfig) -> tuple[list[tuple[str, object]], object]:
     """Run AI enrichment. Returns (changes, enriched_metadata)."""
     m = entry.metadata
     missing = _get_missing_fields(m)

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -275,8 +275,10 @@ def backup(ctx: click.Context) -> None:
 
         raise WstError(
             "usage_error",
-            "Interactive backup requires --format human. Use `wst backup icloud|s3` with an identifier, "
-            "or add non-interactive flags.",
+            (
+                "Interactive backup requires --format human. "
+                "Use `wst backup icloud|s3` with an identifier, or add non-interactive flags."
+            ),
             details={"hint": "Try: wst backup s3 3 --format json"},
             exit_code=2,
         )
@@ -1030,7 +1032,10 @@ def edit(
 
             raise WstError(
                 "usage_error",
-                "This command is interactive by default. Use --set key=value (and -y) for non-interactive mode.",
+                (
+                    "This command is interactive by default. "
+                    "Use --set key=value (and -y) for non-interactive mode."
+                ),
                 details={"hint": "Try: wst edit 1 --set title=\"...\" -y --format json"},
                 exit_code=2,
             )
@@ -1199,16 +1204,14 @@ def _apply_metadata_updates(
     return entry, changes
 
 
-def _get_missing_fields(m: "DocumentMetadata") -> list[str]:
+def _get_missing_fields(m) -> list[str]:
     return [k for k, v in m.model_dump().items() if v is None]
 
 
 def _run_enrich(
     entry: LibraryEntry, config: WstConfig
-) -> tuple[list[tuple[str, object]], "DocumentMetadata"]:
+) -> tuple[list[tuple[str, object]], object]:
     """Run AI enrichment. Returns (changes, enriched_metadata)."""
-    from wst.models import DocumentMetadata  # noqa: F811
-
     m = entry.metadata
     missing = _get_missing_fields(m)
 
@@ -1262,12 +1265,27 @@ def _prompt_doc_type(current: DocType) -> DocType:
 
 
 @cli.command()
-@click.option("--type", "doc_type", type=click.Choice([dt.value for dt in DocType], case_sensitive=False), help="Only fix documents of this type")
-@click.option("--field", multiple=True, help="Only fix documents missing this field (e.g. --field isbn --field toc)")
+@click.option(
+    "--type",
+    "doc_type",
+    type=click.Choice([dt.value for dt in DocType], case_sensitive=False),
+    help="Only fix documents of this type",
+)
+@click.option(
+    "--field",
+    multiple=True,
+    help="Only fix documents missing this field (e.g. --field isbn --field toc)",
+)
 @click.option("--yes", "-y", is_flag=True, help="Auto-accept all changes without prompting")
 @click.option("--dry-run", is_flag=True, help="Show what would be enriched without making changes")
 @click.pass_context
-def fix(ctx: click.Context, doc_type: str | None, field: tuple[str, ...], yes: bool, dry_run: bool) -> None:
+def fix(
+    ctx: click.Context,
+    doc_type: str | None,
+    field: tuple[str, ...],
+    yes: bool,
+    dry_run: bool,
+) -> None:
     """Enrich all documents that have missing metadata fields.
 
     \b

--- a/src/wst/ingest.py
+++ b/src/wst/ingest.py
@@ -177,14 +177,35 @@ def ingest_files(
     auto_confirm: bool = False,
     reprocess: bool = False,
     verbose: bool = False,
-) -> tuple[int, int]:
-    """Ingest a list of document files. Returns (processed, ingested) counts."""
+    *,
+    emit: bool = True,
+    progress: bool = True,
+) -> dict:
+    """Ingest a list of document files.
+
+    Returns a dict summary with keys:
+      - processed, ingested, skipped, failed
+      - results: list[IngestResult] (as dataclasses)
+      - elapsed_seconds
+
+    When emit=False, this function produces no stdout/stderr.
+    When progress=False, no carriage-return progress line is printed.
+    """
     if not files:
-        click.echo("No supported files found.")
-        return 0, 0
+        if emit:
+            click.echo("No supported files found.")
+        return {
+            "processed": 0,
+            "ingested": 0,
+            "skipped": 0,
+            "failed": 0,
+            "results": [],
+            "elapsed_seconds": 0.0,
+        }
 
     total = len(files)
-    click.echo(f"Found {total} file(s)")
+    if emit:
+        click.echo(f"Found {total} file(s)")
 
     results: list[IngestResult] = []
     start_time = time.monotonic()
@@ -192,10 +213,10 @@ def ingest_files(
     for i, doc_path in enumerate(files):
         elapsed = time.monotonic() - start_time
 
-        if not verbose:
+        if emit and progress and not verbose:
             _show_progress(i, total, doc_path.name, elapsed)
 
-        if not verbose and not auto_confirm:
+        if emit and progress and not verbose and not auto_confirm:
             # Need to clear progress line before interactive prompt
             _clear_line()
 
@@ -203,7 +224,7 @@ def ingest_files(
         results.append(result)
 
     # Clear progress line
-    if not verbose:
+    if emit and progress and not verbose:
         _clear_line()
 
     # Summary
@@ -212,22 +233,30 @@ def ingest_files(
     skipped = [r for r in results if r.status == "skipped"]
 
     elapsed = time.monotonic() - start_time
-    eta = _format_eta(elapsed)
-    click.echo(
-        f"\nDone in {eta}: {len(ingested)} ingested, {len(skipped)} skipped, {len(failed)} failed"
-    )
+    if emit:
+        eta = _format_eta(elapsed)
+        click.echo(
+            f"\nDone in {eta}: {len(ingested)} ingested, {len(skipped)} skipped, {len(failed)} failed"
+        )
 
-    if failed:
-        click.echo("\nFailed:")
-        for r in failed:
-            click.echo(f"  - {r.filename}: {r.reason}")
+        if failed:
+            click.echo("\nFailed:")
+            for r in failed:
+                click.echo(f"  - {r.filename}: {r.reason}")
 
-    if skipped and verbose:
-        click.echo("\nSkipped:")
-        for r in skipped:
-            click.echo(f"  - {r.filename}: {r.reason}")
+        if skipped and verbose:
+            click.echo("\nSkipped:")
+            for r in skipped:
+                click.echo(f"  - {r.filename}: {r.reason}")
 
-    return total, len(ingested)
+    return {
+        "processed": total,
+        "ingested": len(ingested),
+        "skipped": len(skipped),
+        "failed": len(failed),
+        "results": results,
+        "elapsed_seconds": elapsed,
+    }
 
 
 def clean_inbox(inbox_path: Path) -> int:

--- a/src/wst/ingest.py
+++ b/src/wst/ingest.py
@@ -236,7 +236,10 @@ def ingest_files(
     if emit:
         eta = _format_eta(elapsed)
         click.echo(
-            f"\nDone in {eta}: {len(ingested)} ingested, {len(skipped)} skipped, {len(failed)} failed"
+            (
+                f"\nDone in {eta}: "
+                f"{len(ingested)} ingested, {len(skipped)} skipped, {len(failed)} failed"
+            )
         )
 
         if failed:

--- a/src/wst/ingest.py
+++ b/src/wst/ingest.py
@@ -236,10 +236,8 @@ def ingest_files(
     if emit:
         eta = _format_eta(elapsed)
         click.echo(
-            (
-                f"\nDone in {eta}: "
-                f"{len(ingested)} ingested, {len(skipped)} skipped, {len(failed)} failed"
-            )
+            f"\nDone in {eta}: "
+            f"{len(ingested)} ingested, {len(skipped)} skipped, {len(failed)} failed"
         )
 
         if failed:

--- a/src/wst/ocr.py
+++ b/src/wst/ocr.py
@@ -166,17 +166,43 @@ def ocr_files(
     language: str = "spa",
     force: bool = False,
     verbose: bool = False,
-) -> list[OcrResult]:
-    """Run OCR on a list of PDF files with progress display."""
+    *,
+    emit: bool = True,
+    progress: bool = True,
+) -> dict:
+    """Run OCR on a list of PDF files.
+
+    Returns a dict summary with keys:
+      - processed, skipped, failed
+      - results: list[OcrResult]
+      - elapsed_seconds
+
+    When emit=False, this function produces no stdout/stderr.
+    When progress=False, no carriage-return progress line is printed.
+    """
     if not files:
-        click.echo("No PDF files found.")
-        return []
+        if emit:
+            click.echo("No PDF files found.")
+        return {
+            "processed": 0,
+            "skipped": 0,
+            "failed": 0,
+            "results": [],
+            "elapsed_seconds": 0.0,
+        }
 
     if not require_ocr_dependencies():
-        return []
+        return {
+            "processed": 0,
+            "skipped": 0,
+            "failed": 0,
+            "results": [],
+            "elapsed_seconds": 0.0,
+        }
 
     total = len(files)
-    click.echo(f"Found {total} PDF(s) to process (language: {language})")
+    if emit:
+        click.echo(f"Found {total} PDF(s) to process (language: {language})")
 
     results: list[OcrResult] = []
     start_time = time.monotonic()
@@ -184,16 +210,16 @@ def ocr_files(
     for i, pdf_path in enumerate(files):
         elapsed = time.monotonic() - start_time
 
-        if not verbose:
+        if emit and progress and not verbose:
             _show_progress(i, total, pdf_path.name, elapsed)
 
-        if verbose:
+        if emit and verbose:
             click.echo(f"\nProcessing: {pdf_path.name}")
 
         result = run_ocr(pdf_path, language=language, force=force)
         results.append(result)
 
-        if verbose:
+        if emit and verbose:
             if result.status == "processed":
                 click.echo(f"  OCR complete: {pdf_path.name}")
             elif result.status == "skipped":
@@ -201,7 +227,7 @@ def ocr_files(
             else:
                 click.echo(f"  Failed: {result.reason}")
 
-    if not verbose:
+    if emit and progress and not verbose:
         _clear_line()
 
     # Summary
@@ -210,16 +236,23 @@ def ocr_files(
     failed = [r for r in results if r.status == "failed"]
 
     elapsed = time.monotonic() - start_time
-    eta = _format_eta(elapsed)
-    click.echo(
-        f"\nOCR done in {eta}: "
-        f"{len(processed)} processed, {len(skipped)} skipped, "
-        f"{len(failed)} failed"
-    )
+    if emit:
+        eta = _format_eta(elapsed)
+        click.echo(
+            f"\nOCR done in {eta}: "
+            f"{len(processed)} processed, {len(skipped)} skipped, "
+            f"{len(failed)} failed"
+        )
 
-    if failed:
-        click.echo("\nFailed:")
-        for r in failed:
-            click.echo(f"  - {r.filename}: {r.reason}")
+        if failed:
+            click.echo("\nFailed:")
+            for r in failed:
+                click.echo(f"  - {r.filename}: {r.reason}")
 
-    return results
+    return {
+        "processed": len(processed),
+        "skipped": len(skipped),
+        "failed": len(failed),
+        "results": results,
+        "elapsed_seconds": elapsed,
+    }

--- a/src/wst/output.py
+++ b/src/wst/output.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import click
+from pydantic import BaseModel
+
+
+class WstError(Exception):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: dict[str, Any] | None = None,
+        exit_code: int = 1,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details
+        self.exit_code = exit_code
+
+
+def to_payload(obj: Any) -> Any:
+    if obj is None:
+        return None
+
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+
+    if isinstance(obj, Path):
+        return str(obj)
+
+    if isinstance(obj, Enum):
+        return obj.value
+
+    if dataclasses.is_dataclass(obj):
+        return {k: to_payload(v) for k, v in dataclasses.asdict(obj).items()}
+
+    if isinstance(obj, BaseModel):
+        return {k: to_payload(v) for k, v in obj.model_dump().items()}
+
+    if isinstance(obj, dict):
+        return {str(k): to_payload(v) for k, v in obj.items()}
+
+    if isinstance(obj, (list, tuple, set)):
+        return [to_payload(v) for v in obj]
+
+    return str(obj)
+
+
+def _ok(data: Any) -> dict[str, Any]:
+    return {"ok": True, "data": to_payload(data)}
+
+
+def _err(code: str, message: str, details: dict[str, Any] | None) -> dict[str, Any]:
+    return {"ok": False, "error": {"code": code, "message": message, "details": to_payload(details)}}
+
+
+def render_ok(data: Any, *, fmt: str) -> None:
+    payload = _ok(data)
+    _render_payload(payload, fmt=fmt)
+
+
+def render_error(
+    *,
+    code: str,
+    message: str,
+    details: dict[str, Any] | None,
+    fmt: str,
+) -> None:
+    payload = _err(code, message, details)
+    _render_payload(payload, fmt=fmt)
+
+
+def _render_payload(payload: dict[str, Any], *, fmt: str) -> None:
+    fmt = fmt.lower()
+    if fmt == "json":
+        click.echo(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return
+    if fmt == "yaml":
+        try:
+            import yaml  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise WstError(
+                "missing_dependency",
+                "YAML output requires PyYAML. Install/update dependencies and retry.",
+                details={"import_error": str(e)},
+                exit_code=2,
+            )
+        click.echo(yaml.safe_dump(payload, sort_keys=True, allow_unicode=True))
+        return
+    if fmt == "md":
+        click.echo(_to_markdown(payload))
+        return
+
+    raise WstError(
+        "usage_error",
+        f"Unknown format: {fmt}",
+        details={"allowed": ["human", "md", "json", "yaml"]},
+        exit_code=2,
+    )
+
+
+def _to_markdown(payload: dict[str, Any]) -> str:
+    lines: list[str] = []
+    ok = payload.get("ok", False)
+    lines.append("# wst output")
+    lines.append("")
+    lines.append(f"- ok: `{ok}`")
+    lines.append("")
+
+    if ok:
+        lines.append("## data")
+        lines.append("")
+        lines.extend(_md_value(payload.get("data")))
+    else:
+        err = payload.get("error", {}) or {}
+        lines.append("## error")
+        lines.append("")
+        lines.append(f"- code: `{err.get('code')}`")
+        lines.append(f"- message: {err.get('message')}")
+        details = err.get("details")
+        if details not in (None, {}, []):
+            lines.append("")
+            lines.append("### details")
+            lines.append("")
+            lines.extend(_md_value(details))
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _md_value(v: Any) -> list[str]:
+    if v is None:
+        return ["- null"]
+
+    if isinstance(v, (str, int, float, bool)):
+        return [f"- `{v}`" if not isinstance(v, str) else f"- {v}"]
+
+    if isinstance(v, list):
+        if not v:
+            return ["- []"]
+        # Try to make a markdown table for list[dict]
+        if all(isinstance(x, dict) for x in v):
+            return _md_table(v)  # type: ignore[arg-type]
+        out: list[str] = []
+        for item in v:
+            out.append(f"- {json.dumps(item, ensure_ascii=False)}")
+        return out
+
+    if isinstance(v, dict):
+        if not v:
+            return ["- {}"]
+        out = []
+        for k in sorted(v.keys()):
+            out.append(f"- **{k}**: {json.dumps(v[k], ensure_ascii=False)}")
+        return out
+
+    return [f"- {json.dumps(v, ensure_ascii=False)}"]
+
+
+def _md_table(rows: list[dict[str, Any]]) -> list[str]:
+    if not rows:
+        return ["- []"]
+    # Collect union of keys
+    keys: list[str] = sorted({k for r in rows for k in r.keys()})
+    header = "| " + " | ".join(keys) + " |"
+    sep = "| " + " | ".join(["---"] * len(keys)) + " |"
+    lines = [header, sep]
+    for r in rows:
+        vals = []
+        for k in keys:
+            val = r.get(k)
+            cell = "" if val is None else json.dumps(val, ensure_ascii=False)
+            vals.append(cell.replace("\n", " "))
+        lines.append("| " + " | ".join(vals) + " |")
+    return lines
+

--- a/src/wst/output.py
+++ b/src/wst/output.py
@@ -59,7 +59,10 @@ def _ok(data: Any) -> dict[str, Any]:
 
 
 def _err(code: str, message: str, details: dict[str, Any] | None) -> dict[str, Any]:
-    return {"ok": False, "error": {"code": code, "message": message, "details": to_payload(details)}}
+    return {
+        "ok": False,
+        "error": {"code": code, "message": message, "details": to_payload(details)},
+    }
 
 
 def render_ok(data: Any, *, fmt: str) -> None:

--- a/src/wst/output.py
+++ b/src/wst/output.py
@@ -183,4 +183,3 @@ def _md_table(rows: list[dict[str, Any]]) -> list[str]:
             vals.append(cell.replace("\n", " "))
         lines.append("| " + " | ".join(vals) + " |")
     return lines
-

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -84,9 +84,7 @@ class TestPromptBuilders:
         assert "Missing fields to fill" in prompt
 
     def test_enrich_prompt_lists_missing_fields(self):
-        metadata = DocumentMetadata(
-            title="Test", author="Author", doc_type="book"
-        )
+        metadata = DocumentMetadata(title="Test", author="Author", doc_type="book")
         prompt = _build_enrich_prompt(metadata, "", "{}")
         assert "year" in prompt
         assert "publisher" in prompt

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ class TestCLIHelp:
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
         assert "organize your books and PDFs" in result.output
+        assert "--format" in result.output
 
     def test_ingest_help(self):
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- Add global `--format human|md|json|yaml` with structured success/error payloads for machine formats.
- Refactor core commands to render deterministic machine output (no progress bars/prompts in md/json/yaml).
- Make interactive flows scriptable via flags (notably `browse` and `edit`) and add a portable CLI skill at `skills/wst-cli/SKILL.md`.

## Notes
- Untracked `app/` is intentionally not included in this PR.

## Test plan
- [ ] `wst --help` shows `--format` and examples.
- [ ] `wst list --format json` returns `{ ok, data }` payload.
- [ ] `wst show 1 --format yaml` returns structured output.
- [ ] `wst browse --id 1 --action view --format md` works non-interactively.

Made with [Cursor](https://cursor.com)