### PR TITLE
fix(ingest): use KMeans vocabulary for topic assignment during ingest

### DIFF
--- a/src/wst/ingest.py
+++ b/src/wst/ingest.py
@@ -11,6 +11,7 @@ from wst.db import Database
 from wst.document import extract_doc_info, is_supported, write_doc_metadata
 from wst.models import LibraryEntry
 from wst.storage import StorageBackend, build_dest_path
+from wst.topics import assign_topics_single, load_vocabulary
 
 
 @dataclass
@@ -122,6 +123,21 @@ def ingest_file(
         return IngestResult(path.name, "failed", f"Error generating metadata: {e}")
 
     metadata.page_count = page_count
+
+    # If a KMeans vocabulary exists, override the LLM-chosen topics with
+    # vocabulary-constrained ones so ingested docs stay aligned with the corpus.
+    vocabulary = load_vocabulary(db)
+    if vocabulary:
+        doc = {
+            "title": metadata.title,
+            "author": metadata.author,
+            "tags": metadata.tags,
+            "summary": (metadata.summary or "")[:300],
+            "subject": metadata.subject,
+        }
+        constrained = assign_topics_single(ai, vocabulary, doc)
+        if constrained:
+            metadata.topics = constrained
 
     # Build entry (preserve original extension)
     ext = path.suffix.lower()

--- a/src/wst/topics.py
+++ b/src/wst/topics.py
@@ -330,6 +330,22 @@ def _deduplicate_vocabulary(
     return vocabulary
 
 
+def assign_topics_single(
+    ai_backend: AIBackend,
+    vocabulary: list[str],
+    doc: dict,
+) -> list[str]:
+    """Assign 1-3 topics from vocabulary to a single document dict.
+
+    *doc* should have keys: title, author, tags, summary, subject.
+    Returns a list of validated topic strings (may be empty if the AI response
+    cannot be parsed or nothing matches the vocabulary).
+    """
+    prompt = _build_assign_topics_prompt(vocabulary, doc)
+    raw = _call_ai_raw(ai_backend, prompt)
+    return _parse_json_list(raw, vocabulary)
+
+
 def assign_topics(
     db: Database,
     ai_backend: AIBackend,

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -20,6 +20,7 @@ from wst.topics import (
     _name_cluster,
     _parse_json_list,
     assign_topics,
+    assign_topics_single,
     load_vocabulary,
     save_vocabulary,
 )
@@ -173,6 +174,45 @@ class TestParseJsonList:
 # ---------------------------------------------------------------------------
 # assign_topics (mocked AI)
 # ---------------------------------------------------------------------------
+
+
+class TestAssignTopicsSingle:
+    def test_returns_valid_topics(self):
+        vocab = ["Matemáticas", "Literatura"]
+        ai = _mock_ai('["Matemáticas"]')
+        doc = {"title": "Cálculo", "author": "Author", "tags": [], "summary": "", "subject": None}
+        result = assign_topics_single(ai, vocab, doc)
+        assert result == ["Matemáticas"]
+
+    def test_filters_out_of_vocabulary_topics(self):
+        vocab = ["Matemáticas"]
+        ai = _mock_ai('["Matemáticas", "Inventado"]')
+        doc = {"title": "Book", "author": "A", "tags": [], "summary": "", "subject": None}
+        result = assign_topics_single(ai, vocab, doc)
+        assert result == ["Matemáticas"]
+
+    def test_returns_empty_on_bad_ai_response(self):
+        vocab = ["Matemáticas"]
+        ai = _mock_ai("not json at all")
+        doc = {"title": "Book", "author": "A", "tags": [], "summary": "", "subject": None}
+        result = assign_topics_single(ai, vocab, doc)
+        assert result == []
+
+    def test_prompt_contains_vocabulary(self):
+        captured: list[str] = []
+        ai = MagicMock()
+
+        def capture(prompt: str) -> str:
+            captured.append(prompt)
+            return '["Física"]'
+
+        ai._run_claude.side_effect = capture
+        vocab = ["Física", "Literatura"]
+        doc = {"title": "Book", "author": "A", "tags": [], "summary": "", "subject": None}
+        assign_topics_single(ai, vocab, doc)
+        assert captured, "AI was not called"
+        assert "Física" in captured[0]
+        assert "Literatura" in captured[0]
 
 
 class TestAssignTopics:


### PR DESCRIPTION
## Summary

- When ingesting a document, `ingest_file()` called `ai.generate_metadata()` which includes `topics` in the JSON schema — the LLM would fill it in freely, bypassing any KMeans-derived vocabulary.
- Adds `assign_topics_single(ai_backend, vocabulary, doc)` to `topics.py` — a thin wrapper around the existing `_build_assign_topics_prompt` + `_call_ai_raw` + `_parse_json_list` pipeline already used by `wst topics assign`.
- `ingest_file()` now loads the vocabulary after generating metadata; if one exists, calls `assign_topics_single` and overrides `metadata.topics` with the constrained result (falls back to LLM-chosen topics if the AI response can't be parsed or vocabulary is empty).

Closes #13

## Test plan

- [ ] `TestAssignTopicsSingle` — 4 new unit tests covering valid response, out-of-vocab filtering, bad AI response, and prompt content
- [ ] Full test suite: 127 tests pass (`test_backup.py` excluded due to pre-existing libexpat issue on macOS unrelated to this change)
- [ ] Manual: ingest a document after running `wst topics build` and verify the assigned topics come from the vocabulary