### PR TITLE
RFC: Subject assignment by clustering

### DIFF
--- a/docs/rfcs/0003-subject-by-clustering.md
+++ b/docs/rfcs/0003-subject-by-clustering.md
@@ -1,0 +1,96 @@
+# RFC 0003: Subject Assignment by Clustering
+
+**Issue**: #12  
+**Status**: Draft — awaiting approval  
+**Branch**: `rfc/issue-12-subject-by-clustering`
+
+---
+
+## Problem
+
+Currently, the `subject` field (e.g., "Mathematics", "Computer Science") is assigned by the LLM during `wst ingest`, using only the individual document's content as context. This produces two problems:
+
+1. **Inconsistency across the corpus** — two books on Calculus may get "Mathematics" and "Matemáticas" (or "Cálculo" vs "Math") depending on the document's language and the LLM's mood.
+
+2. **Redundancy with topics** — once `wst topics build` runs, the library already has a curated, consistent topic vocabulary (e.g., "Cálculo", "Álgebra Lineal"). The `subject` field is supposed to be the broader parent area ("Mathematics"), but currently it's set independently and often overlaps with or contradicts the topic assignments.
+
+---
+
+## Proposed Solution
+
+Replace per-document LLM subject inference with **cluster-derived subjects**: after `wst topics build`, assign `subject` values from a small, fixed set of broad academic areas based on the document's assigned topics.
+
+### Two-phase approach
+
+#### Phase 1 — Cluster → broad-area mapping (happens during `wst topics build`)
+
+When the AI names each cluster, also ask it for the cluster's **broad academic area** (1-2 words, e.g., "Mathematics", "Physics", "Computer Science", "Literature"). Store this as a `cluster_subjects` mapping in the `topics_vocabulary` DB row (or as a separate DB table).
+
+Changes to `_build_cluster_naming_prompt` (or a new prompt):
+
+```python
+"""...
+Also return the BROAD ACADEMIC AREA for this cluster (1-2 words in English,
+e.g. "Mathematics", "Computer Science", "Literature", "Physics").
+Return as JSON: {"name": "<topic name>", "subject": "<broad area>"}
+"""
+```
+
+#### Phase 2 — Subject backfill during `wst topics assign`
+
+After topics are assigned to each document, set `subject` from the topic → subject map:
+
+```python
+# For each document, pick subject from its primary topic
+for doc_id, topics in topic_assignments.items():
+    if topics:
+        primary_topic = topics[0]
+        subject = topic_to_subject.get(primary_topic)
+        if subject:
+            db.update_subject(doc_id, subject)
+```
+
+If a document has multiple topics that map to different subjects (e.g., "Cálculo" → "Mathematics", "Programación" → "Computer Science"), use the subject of the **first (highest-confidence) topic**.
+
+### Backward compatibility
+
+- During `wst ingest`, continue setting `subject` via LLM as today (provides a subject even before topics are built)
+- `wst topics assign` (or `wst topics build --assign`) overwrites `subject` with the cluster-derived value
+- Add a `--skip-subject` flag to `wst topics assign` for users who want to preserve LLM-generated subjects
+
+### Data model change
+
+Extend the stored vocabulary format from `list[str]` to:
+
+```json
+{
+  "topics": ["Cálculo", "Álgebra Lineal", "Programación"],
+  "subjects": {
+    "Cálculo": "Mathematics",
+    "Álgebra Lineal": "Mathematics",
+    "Programación": "Computer Science"
+  }
+}
+```
+
+Or keep as parallel lists; either way requires a DB schema migration or re-running `wst topics build`.
+
+---
+
+## Open Questions
+
+> **Q1**: Should `subject` be updated automatically when `wst topics assign` runs, or should it require an explicit `--update-subject` flag so users can opt in?
+
+> **Q2**: For documents that haven't been through `wst topics build` yet (newly ingested), should we keep the LLM-generated subject or leave `subject` null until topics are built?
+
+> **Q3**: Should we expose the topic→subject mapping in the CLI for users to inspect or override (e.g., `wst topics subjects`)? This would let users fix cases where the AI mapped "Cálculo" → "Science" instead of "Mathematics".
+
+> **Q4**: The current `topic_to_subject` mapping comes from the AI naming the cluster. Would you prefer a hardcoded allow-list of subjects (e.g., the Dewey decimal top-level categories) to enforce consistency, letting the AI only *choose* from the list?
+
+---
+
+## Files Changed (implementation phase)
+
+- `src/wst/topics.py` — update `_build_cluster_naming_prompt` to also return subject; update `build_vocabulary` to store subject mapping; add `backfill_subjects` function
+- `src/wst/db.py` — update `save_topics_vocabulary` / `load_topics_vocabulary` to handle the extended format; add `update_subject(doc_id, subject)`
+- `src/wst/cli.py` — update `wst topics build` and `wst topics assign` to run subject backfill

--- a/docs/rfcs/0003-subject-by-clustering.md
+++ b/docs/rfcs/0003-subject-by-clustering.md
@@ -1,7 +1,7 @@
 # RFC 0003: Subject Assignment by Clustering
 
 **Issue**: #12  
-**Status**: Draft — awaiting approval  
+**Status**: Approved — implementation in progress  
 **Branch**: `rfc/issue-12-subject-by-clustering`
 
 ---
@@ -10,87 +10,70 @@
 
 Currently, the `subject` field (e.g., "Mathematics", "Computer Science") is assigned by the LLM during `wst ingest`, using only the individual document's content as context. This produces two problems:
 
-1. **Inconsistency across the corpus** — two books on Calculus may get "Mathematics" and "Matemáticas" (or "Cálculo" vs "Math") depending on the document's language and the LLM's mood.
+1. **Inconsistency across the corpus** — two books on Calculus may get "Mathematics" and "Matemáticas" depending on the document's language.
 
-2. **Redundancy with topics** — once `wst topics build` runs, the library already has a curated, consistent topic vocabulary (e.g., "Cálculo", "Álgebra Lineal"). The `subject` field is supposed to be the broader parent area ("Mathematics"), but currently it's set independently and often overlaps with or contradicts the topic assignments.
+2. **Redundancy with topics** — once `wst topics build` runs, the library already has a curated topic vocabulary. The `subject` field should be the broader parent area ("Mathematics"), but it is set independently and often overlaps with or contradicts topic assignments.
 
 ---
 
-## Proposed Solution
+## Approved Solution
 
-Replace per-document LLM subject inference with **cluster-derived subjects**: after `wst topics build`, assign `subject` values from a small, fixed set of broad academic areas based on the document's assigned topics.
+Replace per-document LLM subject inference with **two-level clustering**: after `wst topics build` produces fine-grained topic clusters, run a **second KMeans pass** on those cluster centroids with a smaller K to produce broader subject groups. The AI names the subject groups (which are inherently broader because they already aggregate multiple related topics).
 
 ### Two-phase approach
 
-#### Phase 1 — Cluster → broad-area mapping (happens during `wst topics build`)
+#### Phase 1 — Subject clustering (happens inside `wst topics build`)
 
-When the AI names each cluster, also ask it for the cluster's **broad academic area** (1-2 words, e.g., "Mathematics", "Physics", "Computer Science", "Literature"). Store this as a `cluster_subjects` mapping in the `topics_vocabulary` DB row (or as a separate DB table).
-
-Changes to `_build_cluster_naming_prompt` (or a new prompt):
+After the main KMeans produces `k` topic centroids, run a second KMeans on those centroids:
 
 ```python
-"""...
-Also return the BROAD ACADEMIC AREA for this cluster (1-2 words in English,
-e.g. "Mathematics", "Computer Science", "Literature", "Physics").
-Return as JSON: {"name": "<topic name>", "subject": "<broad area>"}
-"""
+n_subjects = min(max(2, k // 3), k - 1, 8)
+km2 = KMeans(n_clusters=n_subjects, random_state=42, n_init="auto")
+super_labels = km2.fit_predict(centroids)   # maps each topic → subject cluster
 ```
 
-#### Phase 2 — Subject backfill during `wst topics assign`
+For each subject cluster, gather the topic names it contains and ask the AI to name the group:
 
-After topics are assigned to each document, set `subject` from the topic → subject map:
+```
+Topics in this group: ["Cálculo", "Álgebra Lineal", "Geometría"]
+→ AI response: "Matemáticas"
+```
+
+This produces a `topic_to_subject` mapping: `{"Cálculo": "Matemáticas", "Álgebra Lineal": "Matemáticas", ...}`.
+
+#### Phase 2 — Subject backfill (runs automatically in `wst topics assign`)
+
+After topics are assigned to each document, set `subject` from the primary (first) topic:
 
 ```python
-# For each document, pick subject from its primary topic
-for doc_id, topics in topic_assignments.items():
-    if topics:
-        primary_topic = topics[0]
-        subject = topic_to_subject.get(primary_topic)
+for entry in db.list_all():
+    if entry.metadata.topics:
+        subject = topic_to_subject.get(entry.metadata.topics[0])
         if subject:
-            db.update_subject(doc_id, subject)
+            entry.metadata.subject = subject
+            db.update(entry)
 ```
 
-If a document has multiple topics that map to different subjects (e.g., "Cálculo" → "Mathematics", "Programación" → "Computer Science"), use the subject of the **first (highest-confidence) topic**.
+### Approved answers to open questions
 
-### Backward compatibility
-
-- During `wst ingest`, continue setting `subject` via LLM as today (provides a subject even before topics are built)
-- `wst topics assign` (or `wst topics build --assign`) overwrites `subject` with the cluster-derived value
-- Add a `--skip-subject` flag to `wst topics assign` for users who want to preserve LLM-generated subjects
+- **Q1** — Automatic: `wst topics assign` always backfills subjects; no flag needed.
+- **Q2** — LLM fallback: during `wst ingest`, keep setting subject via LLM. Topics build overwrites it.
+- **Q3** — Yes: `wst topics subjects` command lists the topic→subject mapping so users can inspect it.
+- **Q4** — No hardcoded allow-list: the AI freely names the subject groups in Spanish.
 
 ### Data model change
 
-Extend the stored vocabulary format from `list[str]` to:
+Extend `topics_vocabulary` table with a `subjects` column:
 
-```json
-{
-  "topics": ["Cálculo", "Álgebra Lineal", "Programación"],
-  "subjects": {
-    "Cálculo": "Mathematics",
-    "Álgebra Lineal": "Mathematics",
-    "Programación": "Computer Science"
-  }
-}
+```sql
+ALTER TABLE topics_vocabulary ADD COLUMN subjects TEXT;
+-- subjects column: '{"Cálculo": "Matemáticas", "Programación": "Ciencias de la Computación", ...}'
 ```
 
-Or keep as parallel lists; either way requires a DB schema migration or re-running `wst topics build`.
-
 ---
 
-## Open Questions
+## Files Changed
 
-> **Q1**: Should `subject` be updated automatically when `wst topics assign` runs, or should it require an explicit `--update-subject` flag so users can opt in?
-
-> **Q2**: For documents that haven't been through `wst topics build` yet (newly ingested), should we keep the LLM-generated subject or leave `subject` null until topics are built?
-
-> **Q3**: Should we expose the topic→subject mapping in the CLI for users to inspect or override (e.g., `wst topics subjects`)? This would let users fix cases where the AI mapped "Cálculo" → "Science" instead of "Mathematics".
-
-> **Q4**: The current `topic_to_subject` mapping comes from the AI naming the cluster. Would you prefer a hardcoded allow-list of subjects (e.g., the Dewey decimal top-level categories) to enforce consistency, letting the AI only *choose* from the list?
-
----
-
-## Files Changed (implementation phase)
-
-- `src/wst/topics.py` — update `_build_cluster_naming_prompt` to also return subject; update `build_vocabulary` to store subject mapping; add `backfill_subjects` function
-- `src/wst/db.py` — update `save_topics_vocabulary` / `load_topics_vocabulary` to handle the extended format; add `update_subject(doc_id, subject)`
-- `src/wst/cli.py` — update `wst topics build` and `wst topics assign` to run subject backfill
+- `src/wst/topics.py` — add `_build_subject_naming_prompt`, `_build_subject_mapping`, `backfill_subjects`; update `build_vocabulary` return to include `topic_to_subject`; update `save_vocabulary` to persist subjects
+- `src/wst/db.py` — extend `TOPICS_VOCABULARY_SCHEMA` with `subjects` column; add `save_topics_vocabulary(vocab, subjects)`, `load_topics_subjects()`, `update_subject(doc_id, subject)` migration
+- `src/wst/cli.py` — update `topics build` and `topics assign` to backfill subjects; add `wst topics subjects` subcommand

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -1664,9 +1664,10 @@ def topics(ctx: click.Context) -> None:
 
     \b
     Commands:
-      build   Generate vocabulary from corpus and assign to all documents.
-      list    Show the current topic vocabulary.
-      assign  (Re)assign topics to one or all documents.
+      build     Generate vocabulary from corpus and assign to all documents.
+      list      Show the current topic vocabulary.
+      assign    (Re)assign topics to one or all documents.
+      subjects  Show the topic → subject mapping.
     """
 
 
@@ -1703,7 +1704,7 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
     db = Database(config.db_path)
 
     try:
-        from wst.topics import assign_topics, build_vocabulary, save_vocabulary
+        from wst.topics import assign_topics, backfill_subjects, build_vocabulary, save_vocabulary
 
         # Check for existing vocabulary
         existing = db.load_topics_vocabulary()
@@ -1726,8 +1727,10 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
         ai = get_ai_backend(config.ai_backend, config.ai_model)
 
         if fmt == "human":
-            click.echo("Step 1/3  Embedding documents and clustering...")
-        vocabulary, representative_docs = build_vocabulary(db, ai, n_topics=n_topics)
+            click.echo("Step 1/4  Embedding documents and clustering...")
+        vocabulary, representative_docs, topic_to_subject = build_vocabulary(
+            db, ai, n_topics=n_topics
+        )
 
         if not vocabulary:
             if fmt == "human":
@@ -1749,16 +1752,16 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
                 return
 
         if fmt == "human":
-            click.echo("Step 2/3  Assigning topics to documents...")
+            click.echo("Step 2/4  Assigning topics to documents...")
 
         assignments = assign_topics(db, ai, vocabulary)
 
         if fmt == "human":
-            click.echo("Step 3/3  Saving to database...")
+            click.echo("Step 3/4  Saving to database...")
 
-        save_vocabulary(db, vocabulary)
+        save_vocabulary(db, vocabulary, topic_to_subject)
 
-        # Persist assignments
+        # Persist topic assignments
         entries = db.list_all()
         entry_map = {e.id: e for e in entries}
         for doc_id, assigned in assignments.items():
@@ -1768,8 +1771,14 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
             entry.metadata.topics = assigned
             db.update(entry)
 
+        # Backfill subjects from topic→subject mapping
+        if fmt == "human":
+            click.echo("Step 4/4  Backfilling subjects from topic clusters...")
+        subject_updated = backfill_subjects(db, topic_to_subject)
+
         if fmt == "human":
             click.echo(f"\nDone. {len(assignments)} document(s) assigned topics.")
+            click.echo(f"      {subject_updated} document(s) had their subject updated.")
             click.echo(f"Vocabulary ({len(vocabulary)}): {', '.join(vocabulary)}")
             return
 
@@ -1778,7 +1787,9 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
         render_ok(
             {
                 "vocabulary": vocabulary,
+                "subjects": topic_to_subject,
                 "assigned_count": len(assignments),
+                "subjects_updated": subject_updated,
                 "assignments": {str(k): v for k, v in assignments.items()},
             },
             fmt=fmt,
@@ -1848,7 +1859,7 @@ def topics_assign(ctx: click.Context, doc_id: int | None, yes: bool) -> None:
     db = Database(config.db_path)
 
     try:
-        from wst.topics import assign_topics
+        from wst.topics import assign_topics, backfill_subjects
 
         vocabulary = db.load_topics_vocabulary()
         if not vocabulary:
@@ -1897,8 +1908,14 @@ def topics_assign(ctx: click.Context, doc_id: int | None, yes: bool) -> None:
             db.update(entry)
             updated += 1
 
+        # Backfill subjects from stored topic→subject mapping
+        topic_to_subject = db.load_topics_subjects()
+        subject_updated = backfill_subjects(db, topic_to_subject) if topic_to_subject else 0
+
         if fmt == "human":
             click.echo(f"Assigned topics to {updated} document(s).")
+            if subject_updated:
+                click.echo(f"Updated subjects for {subject_updated} document(s).")
             return
 
         from wst.output import render_ok
@@ -1906,10 +1923,57 @@ def topics_assign(ctx: click.Context, doc_id: int | None, yes: bool) -> None:
         render_ok(
             {
                 "updated": updated,
+                "subjects_updated": subject_updated,
                 "assignments": {str(k): v for k, v in assignments.items()},
             },
             fmt=fmt,
         )
+    finally:
+        db.close()
+
+
+@topics.command("subjects")
+@command_format_option()
+@click.pass_context
+def topics_subjects(ctx: click.Context) -> None:
+    """Show the topic → subject mapping derived from clustering.
+
+    \b
+    Examples:
+        wst topics subjects
+        wst topics subjects --format json
+    """
+    config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
+    db = Database(config.db_path)
+
+    try:
+        topic_to_subject = db.load_topics_subjects()
+        if not topic_to_subject:
+            if fmt == "human":
+                click.echo("No subject mapping found. Run `wst topics build` first.")
+                return
+            from wst.output import render_ok
+
+            render_ok({"subjects": {}}, fmt=fmt)
+            return
+
+        if fmt == "human":
+            # Group by subject for readability
+            from collections import defaultdict
+
+            by_subject: dict[str, list[str]] = defaultdict(list)
+            for topic, subject in topic_to_subject.items():
+                by_subject[subject].append(topic)
+            click.echo(f"Topic → Subject mapping ({len(topic_to_subject)} topics):")
+            for subject in sorted(by_subject):
+                topics_in = ", ".join(sorted(by_subject[subject]))
+                click.echo(f"  {subject}: {topics_in}")
+            return
+
+        from wst.output import render_ok
+
+        render_ok({"subjects": topic_to_subject}, fmt=fmt)
     finally:
         db.close()
 
@@ -1979,7 +2043,7 @@ def _fix_topics_cmd(
     doc_type: str | None,
 ) -> None:
     """Assign topics (from existing vocabulary) to documents that have none."""
-    from wst.topics import assign_topics
+    from wst.topics import assign_topics, backfill_subjects
 
     vocabulary = db.load_topics_vocabulary()
     if not vocabulary:
@@ -2044,6 +2108,9 @@ def _fix_topics_cmd(
         entry.metadata.topics = assigned_topics
         db.update(entry)
         updated += 1
+
+    topic_to_subject = db.load_topics_subjects()
+    backfill_subjects(db, topic_to_subject)
 
     if fmt == "human":
         click.echo(f"Assigned topics to {updated} document(s).")

--- a/src/wst/db.py
+++ b/src/wst/db.py
@@ -56,6 +56,7 @@ TOPICS_VOCABULARY_SCHEMA = """
 CREATE TABLE IF NOT EXISTS topics_vocabulary (
     id      INTEGER PRIMARY KEY CHECK (id = 1),
     topics  TEXT NOT NULL,
+    subjects TEXT,
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 """
@@ -101,6 +102,9 @@ class Database:
             self.conn.executescript(FTS_SCHEMA)
 
         self.conn.executescript(TOPICS_VOCABULARY_SCHEMA)
+        if not _has_column(self.conn, "topics_vocabulary", "subjects"):
+            self.conn.execute("ALTER TABLE topics_vocabulary ADD COLUMN subjects TEXT")
+            self.conn.commit()
 
     def _rebuild_fts(self) -> None:
         """Drop and recreate FTS table with the current schema, then repopulate."""
@@ -317,11 +321,15 @@ class Database:
         ).fetchone()
         return self._row_to_entry(row) if row else None
 
-    def save_topics_vocabulary(self, vocabulary: list[str]) -> None:
+    def save_topics_vocabulary(
+        self,
+        vocabulary: list[str],
+        subjects: dict[str, str] | None = None,
+    ) -> None:
         self.conn.execute(
-            "INSERT OR REPLACE INTO topics_vocabulary(id, topics, updated_at)"
-            " VALUES (1, ?, datetime('now'))",
-            (json.dumps(vocabulary),),
+            "INSERT OR REPLACE INTO topics_vocabulary(id, topics, subjects, updated_at)"
+            " VALUES (1, ?, ?, datetime('now'))",
+            (json.dumps(vocabulary), json.dumps(subjects) if subjects else None),
         )
         self.conn.commit()
 
@@ -330,6 +338,18 @@ class Database:
         if row is None:
             return None
         return json.loads(row["topics"])
+
+    def load_topics_subjects(self) -> dict[str, str]:
+        row = self.conn.execute("SELECT subjects FROM topics_vocabulary WHERE id = 1").fetchone()
+        if row is None or row["subjects"] is None:
+            return {}
+        return json.loads(row["subjects"])
+
+    def update_subject(self, doc_id: int, subject: str | None) -> None:
+        entry = self.get(doc_id)
+        if entry is not None:
+            entry.metadata.subject = subject
+            self.update(entry)
 
     def _row_to_entry(self, row: sqlite3.Row) -> LibraryEntry:
         tags = json.loads(row["tags"]) if row["tags"] else []

--- a/src/wst/topics.py
+++ b/src/wst/topics.py
@@ -72,6 +72,24 @@ Respondé con exactamente dos nombres, uno por línea, en español, 1-3 palabras
 No pongas explicaciones, numeración, ni puntuación — solo los dos nombres."""
 
 
+def _build_subject_naming_prompt(topic_names: list[str]) -> str:
+    """Build a prompt asking the AI to name a super-cluster of topics as a broad subject."""
+    topics_str = ", ".join(f'"{t}"' for t in topic_names)
+    return f"""You are helping build a subject classification for an academic/personal library.
+
+Below are related topics clustered by semantic similarity.
+Your task: give this group a SHORT, BROAD ACADEMIC SUBJECT name (1-3 words) covering all of them.
+Examples: "Matemáticas", "Ciencias de la Computación", "Literatura", "Física", "Economía".
+
+Rules:
+- 1 to 3 words maximum.
+- In Spanish.
+- Broad / high-level (a subject area, not a specific subtopic).
+- Return ONLY the subject name, nothing else — no explanation, no punctuation, no quotes.
+
+Topics in this group: [{topics_str}]"""
+
+
 def _build_assign_topics_prompt(vocabulary: list[str], doc: dict) -> str:
     """Build a prompt asking Claude to assign topics to a document."""
     vocab_str = ", ".join(f'"{t}"' for t in vocabulary)
@@ -97,20 +115,21 @@ def build_vocabulary(
     db: Database,
     ai_backend: AIBackend,
     n_topics: int | None = None,
-) -> tuple[list[str], dict[int, list[str]]]:
+) -> tuple[list[str], dict[int, list[str]], dict[str, str]]:
     """Generate a topic vocabulary from the document corpus.
 
     Steps:
       1. Extract all documents.
       2. Embed title + tags + summary with a multilingual sentence-transformer.
       3. Determine optimal cluster count (silhouette) or use n_topics.
-      4. KMeans clustering.
-      5. For each cluster, name it via AI.
+      4. KMeans clustering → topic names.
+      5. Second KMeans on topic centroids → broader subject groups, named via AI.
 
-    Returns a tuple (vocabulary, representative_docs) where:
+    Returns a tuple (vocabulary, representative_docs, topic_to_subject) where:
       - vocabulary is a list of topic name strings.
       - representative_docs is a dict mapping cluster index to a list of up to 3
         document titles that are closest to the cluster centroid.
+      - topic_to_subject maps each topic name to its broad subject name.
     """
     try:
         import numpy as np
@@ -141,7 +160,7 @@ def build_vocabulary(
 
     entries = db.list_all()
     if not entries:
-        return [], {}
+        return [], {}, {}
 
     # Build text representations
     texts: list[str] = []
@@ -171,8 +190,9 @@ def build_vocabulary(
     if n_docs < 2:
         # Can't cluster a single document — just name it directly
         topic = _name_cluster(ai_backend, doc_metas[:1])
+        subject = _call_ai_raw(ai_backend, _build_subject_naming_prompt([topic])).strip().strip('"')
         representative_docs = {0: [doc_metas[0]["title"]]}
-        return [topic], representative_docs
+        return [topic], representative_docs, {topic: subject}
 
     # Determine number of clusters
     if n_topics is not None:
@@ -216,7 +236,63 @@ def build_vocabulary(
     # Resolve duplicate names (e.g. two clusters both named "Álgebra Lineal")
     _deduplicate_vocabulary(ai_backend, vocabulary, cluster_docs_map)
 
-    return vocabulary, representative_docs
+    # Second KMeans on topic centroids → broader subject groups
+    topic_to_subject = _build_subject_mapping(ai_backend, vocabulary, centroids, k)
+
+    return vocabulary, representative_docs, topic_to_subject
+
+
+def _build_subject_mapping(
+    ai_backend: AIBackend,
+    vocabulary: list[str],
+    centroids,
+    k: int,
+) -> dict[str, str]:
+    """Run a second KMeans on topic centroids to derive broader subject names.
+
+    Each subject cluster groups several related topics; the AI names the group
+    with a broad academic area (e.g. "Matemáticas", "Literatura").
+    """
+    from sklearn.cluster import KMeans  # type: ignore[import-not-found]
+
+    if k < 4:
+        # Too few topics — name each individually as a subject
+        subject_map: dict[str, str] = {}
+        for topic in vocabulary:
+            raw = _call_ai_raw(ai_backend, _build_subject_naming_prompt([topic]))
+            subject_map[topic] = raw.strip().strip('"').strip("'").strip()
+        return subject_map
+
+    n_subjects = min(max(2, k // 3), k - 1, 8)
+    km2 = KMeans(n_clusters=n_subjects, random_state=42, n_init="auto")
+    super_labels = km2.fit_predict(centroids)
+
+    subject_map = {}
+    for s_idx in range(n_subjects):
+        topic_indices = [i for i, lbl in enumerate(super_labels) if lbl == s_idx]
+        topic_names = [vocabulary[i] for i in topic_indices]
+        raw = _call_ai_raw(ai_backend, _build_subject_naming_prompt(topic_names))
+        subject_name = raw.strip().strip('"').strip("'").strip()
+        for t in topic_names:
+            subject_map[t] = subject_name
+    return subject_map
+
+
+def backfill_subjects(db: Database, topic_to_subject: dict[str, str]) -> int:
+    """Set subject on every document based on its primary topic.
+
+    Returns the number of documents updated.
+    """
+    updated = 0
+    for entry in db.list_all():
+        if not entry.metadata.topics:
+            continue
+        subject = topic_to_subject.get(entry.metadata.topics[0])
+        if subject and subject != entry.metadata.subject:
+            entry.metadata.subject = subject
+            db.update(entry)
+            updated += 1
+    return updated
 
 
 def _optimal_k(embeddings, min_k: int = 2, max_k: int = 20) -> int:
@@ -412,9 +488,13 @@ def _parse_json_list(raw: str, vocabulary: list[str]) -> list[str]:
     return []
 
 
-def save_vocabulary(db: Database, vocabulary: list[str]) -> None:
-    """Persist the vocabulary in the DB."""
-    db.save_topics_vocabulary(vocabulary)
+def save_vocabulary(
+    db: Database,
+    vocabulary: list[str],
+    topic_to_subject: dict[str, str] | None = None,
+) -> None:
+    """Persist the vocabulary and optional subject mapping in the DB."""
+    db.save_topics_vocabulary(vocabulary, subjects=topic_to_subject)
 
 
 def load_vocabulary(db: Database) -> list[str] | None:

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -264,9 +264,10 @@ class TestBuildVocabulary:
 
         ai = _mock_ai("Cálculo")
         with patch.dict(sys.modules, self._fake_modules()):
-            vocab, rep_docs = build_vocabulary(db, ai)
+            vocab, rep_docs, topic_to_subject = build_vocabulary(db, ai)
         assert vocab == []
         assert rep_docs == {}
+        assert topic_to_subject == {}
 
     def test_raises_on_missing_deps(self, db):
         """build_vocabulary raises RuntimeError when sentence-transformers is missing."""
@@ -289,12 +290,12 @@ class TestBuildVocabulary:
         # Mock the entire function to avoid heavy ML dependencies in CI
         with patch(
             "wst.topics.build_vocabulary",
-            return_value=(["Matemáticas", "Literatura"], {}),
+            return_value=(["Matemáticas", "Literatura"], {}, {}),
         ):
             from wst.topics import build_vocabulary
 
             ai = _mock_ai("Matemáticas")
-            vocab, rep_docs = build_vocabulary(db, ai, n_topics=2)
+            vocab, rep_docs, topic_to_subject = build_vocabulary(db, ai, n_topics=2)
 
         assert isinstance(vocab, list)
         assert len(vocab) == 2
@@ -673,7 +674,7 @@ class TestTopicsBuildNonInteractive:
         runner = CliRunner()
         with (
             patch("wst.cli.WstConfig", return_value=cfg),
-            patch("wst.topics.build_vocabulary", return_value=(fake_vocab, {})),
+            patch("wst.topics.build_vocabulary", return_value=(fake_vocab, {}, {})),
             patch("wst.topics.assign_topics", return_value={1: ["Matemáticas"], 2: ["Ciencias"]}),
             patch("wst.topics.save_vocabulary") as mock_save,
         ):
@@ -695,7 +696,7 @@ class TestTopicsBuildNonInteractive:
         runner = CliRunner()
         with (
             patch("wst.cli.WstConfig", return_value=cfg),
-            patch("wst.topics.build_vocabulary", return_value=(fake_vocab, {})),
+            patch("wst.topics.build_vocabulary", return_value=(fake_vocab, {}, {})),
             patch("wst.topics.assign_topics", return_value={1: ["Física"], 2: ["Literatura"]}),
             patch("wst.topics.save_vocabulary") as mock_save,
         ):


### PR DESCRIPTION
Closes #12

## Summary

RFC 0003 proposes replacing per-document LLM subject inference with cluster-derived subjects: when naming clusters during `wst topics build`, also capture the broad academic area (Mathematics, Computer Science, etc.) and backfill it into all documents assigned to that cluster.

**Problem**: LLM-generated subjects are inconsistent across the corpus (language variation, randomness) and redundant with the topics vocabulary.

**Proposal**: Two-phase — (1) capture broad area per cluster during topics build, (2) backfill subject from the topic→subject map during topics assign.

See `docs/rfcs/0003-subject-by-clustering.md` for full design.

## Before I implement

Leave a comment on this PR or issue #12:
- Approved — I'll add implementation to this PR
- Changes requested — I'll revise the RFC

Key questions Q1–Q4 in the RFC (notably: auto-update vs opt-in flag, and hardcoded subject allow-list?).