### PR TITLE
RFC: Consistent cover display for docs without ISBN

### DIFF
--- a/docs/rfcs/0004-cover-consistency.md
+++ b/docs/rfcs/0004-cover-consistency.md
@@ -1,0 +1,92 @@
+# RFC 0004: Consistent Cover Display for Documents Without ISBN
+
+**Issue**: #11  
+**Status**: Draft — awaiting approval  
+**Branch**: `rfc/issue-11-cover-consistency`
+
+---
+
+## Problem
+
+Some documents without an ISBN show **no cover** in the app while others show the **first PDF page** as a cover. The behavior is inconsistent.
+
+### Root cause analysis
+
+The cover system has two layers:
+
+1. **Python CLI** (`src/wst/covers.py`) — `ensure_cover()` generates and caches covers in `.covers/<id>.jpg`
+2. **Tauri app** (`app/src-tauri/src/covers.rs`) — `CoverManager::get_cover_filename()` checks if the cached file exists
+
+`ensure_cover` is only called by `wst covers` (not during ingest). The fallback path for no-ISBN documents:
+
+```python
+pdf_path = library_path / file_path
+if pdf_path.exists():
+    data = render_pdf_first_page(pdf_path)
+```
+
+Likely failure modes (causing inconsistency):
+
+**A) `pdf_path.exists()` returns false** when `file_path` in the DB is an absolute path (e.g., iCloud-backed files whose path starts with `/`). `library_path / absolute_path` silently produces an incorrect path on Python < 3.12 when `file_path` doesn't start with `/` (it joins correctly), but if the path is the full absolute path, the join could fail.
+
+**B) `render_pdf_first_page` fails silently** for some PDFs (encrypted, unusual encoding, zero-dimension page) and returns `None` — the cover is never written and the failure is only visible in the CLI output (`failed`), not the app.
+
+**C) `wst covers` was run before some documents were ingested** — those documents simply have no entry in `.covers/` because the command was never run for them. The app has no way to trigger cover generation on demand.
+
+---
+
+## Proposed Solution
+
+Three complementary fixes:
+
+### Fix 1 — Resolve `file_path` correctly
+
+In `ensure_cover`, normalize the path before checking existence:
+
+```python
+pdf_path = Path(file_path) if Path(file_path).is_absolute() else library_path / file_path
+```
+
+This handles the case where some entries have absolute paths (e.g., iCloud storage).
+
+### Fix 2 — Auto-generate covers during ingest
+
+Call `ensure_cover` at the end of `ingest_file` so every document gets a cover immediately on ingest, not only when the user runs `wst covers`:
+
+```python
+# In ingest_file(), after entry.id = db.insert(entry):
+ensure_cover(config.library_path, entry.id, metadata.isbn, entry.file_path)
+```
+
+This eliminates the "covers exist for old docs but not new ones" gap.
+
+### Fix 3 — Placeholder cover in the app for unresolvable covers
+
+When `get_cover_filename` returns `None`, the Tauri app currently shows nothing (or crashes). Add a fallback so the app renders a generic placeholder:
+
+In `CoverImage.tsx` (or equivalent component), when `cover_path` is null, display an SVG placeholder with the document title initials instead of an empty box.
+
+---
+
+## Alternative Considered
+
+**On-demand cover generation from the app**: trigger `wst covers --id <doc_id>` via `run_wst_command` when the app requests a cover and none is cached. This avoids the ingest-time overhead but adds latency to the app's first load. Rejected because Fix 2 is simpler and ingest already calls the AI, so the additional PDF rendering cost is negligible.
+
+---
+
+## Open Questions
+
+> **Q1**: Should we also add a `wst covers --missing` flag that only processes documents currently without a cached cover (for users who have existing libraries where some covers are missing)?
+
+> **Q2**: For the path resolution (Fix 1), are there documents in your library where `file_path` is stored as an absolute path? If so, are those iCloud paths or S3 paths? This affects whether Fix 1 is the right approach or whether we need to special-case remote backends.
+
+> **Q3**: For the app placeholder (Fix 3), do you want a styled placeholder (title initials in a colored box) or just an icon? I can prototype both.
+
+---
+
+## Files Changed (implementation phase)
+
+- `src/wst/covers.py` — Fix 1: normalize `file_path` in `ensure_cover`
+- `src/wst/ingest.py` — Fix 2: call `ensure_cover` after ingest insert
+- `app/src/components/CoverImage.tsx` — Fix 3: render placeholder when cover is null
+- `app/src-tauri/src/commands.rs` — (optionally) add `get_cover` command that triggers generation if missing

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -285,6 +285,7 @@ def ingest(
             verbose=verbose,
             emit=(fmt == "human"),
             progress=(fmt == "human"),
+            library_path=config.library_path,
         )
 
         if path is None and not keep_inbox:
@@ -1576,8 +1577,14 @@ def fix(
     type=click.Choice([dt.value for dt in DocType], case_sensitive=False),
     help="Only process documents of this type",
 )
+@click.option(
+    "--missing",
+    is_flag=True,
+    default=False,
+    help="List documents missing covers without generating them",
+)
 @click.pass_context
-def covers(ctx: click.Context, doc_type: str | None) -> None:
+def covers(ctx: click.Context, doc_type: str | None, missing: bool) -> None:
     """Download and cache cover images for all documents.
 
     \b
@@ -1591,7 +1598,8 @@ def covers(ctx: click.Context, doc_type: str | None) -> None:
 
     \b
     Examples:
-        wst covers                  # all documents
+        wst covers                  # generate missing covers
+        wst covers --missing        # list docs without covers
         wst covers --type textbook  # only textbooks
     """
     from wst.covers import ensure_cover, get_cached_cover
@@ -1603,11 +1611,24 @@ def covers(ctx: click.Context, doc_type: str | None) -> None:
         entries = db.list_all(doc_type=doc_type)
         total = len(entries)
 
-        already = sum(1 for e in entries if get_cached_cover(config.library_path, e.id) is not None)
-        to_fetch = total - already
-        click.echo(f"Total: {total}, cached: {already}, to fetch: {to_fetch}")
+        missing_entries = [
+            e for e in entries if get_cached_cover(config.library_path, e.id) is None
+        ]
 
-        if to_fetch == 0:
+        if missing:
+            if not missing_entries:
+                click.echo("All documents have covers.")
+                return
+            click.echo(f"{len(missing_entries)} document(s) missing covers:")
+            for e in missing_entries:
+                source = "PDF" if not e.metadata.isbn else "ISBN"
+                click.echo(f"  [{e.id}] {e.metadata.title[:60]} ({source})")
+            return
+
+        already = total - len(missing_entries)
+        click.echo(f"Total: {total}, cached: {already}, to fetch: {len(missing_entries)}")
+
+        if not missing_entries:
             click.echo("All covers are cached.")
             return
 
@@ -1615,14 +1636,11 @@ def covers(ctx: click.Context, doc_type: str | None) -> None:
         failed = 0
         start = time.monotonic()
 
-        for i, entry in enumerate(entries, 1):
-            if get_cached_cover(config.library_path, entry.id) is not None:
-                continue
-
+        for i, entry in enumerate(missing_entries, 1):
             m = entry.metadata
             name = m.title[:40] + ".." if len(m.title) > 42 else m.title
             source = "ISBN" if m.isbn else "PDF"
-            click.echo(f"  [{i}/{total}] {name} ({source})...", nl=False)
+            click.echo(f"  [{i}/{len(missing_entries)}] {name} ({source})...", nl=False)
 
             result = ensure_cover(config.library_path, entry.id, m.isbn, entry.file_path)
 

--- a/src/wst/ingest.py
+++ b/src/wst/ingest.py
@@ -88,6 +88,7 @@ def ingest_file(
     auto_confirm: bool = False,
     reprocess: bool = False,
     verbose: bool = False,
+    library_path: Path | None = None,
 ) -> IngestResult:
     """Ingest a single document file. Returns an IngestResult."""
     if verbose:
@@ -177,6 +178,13 @@ def ingest_file(
     entry.id = db.insert(entry)
     if verbose:
         click.echo(f"  Ingested -> {final_path}")
+
+    # Generate cover immediately so the app shows it without requiring `wst covers`
+    if library_path is not None:
+        from wst.covers import ensure_cover
+
+        ensure_cover(library_path, entry.id, metadata.isbn, entry.file_path)
+
     return IngestResult(path.name, "ingested", dest_path=final_path)
 
 
@@ -196,6 +204,7 @@ def ingest_files(
     *,
     emit: bool = True,
     progress: bool = True,
+    library_path: Path | None = None,
 ) -> dict:
     """Ingest a list of document files.
 
@@ -236,7 +245,9 @@ def ingest_files(
             # Need to clear progress line before interactive prompt
             _clear_line()
 
-        result = ingest_file(doc_path, ai, storage, db, auto_confirm, reprocess, verbose)
+        result = ingest_file(
+            doc_path, ai, storage, db, auto_confirm, reprocess, verbose, library_path
+        )
         results.append(result)
 
     # Clear progress line


### PR DESCRIPTION
Closes #11. RFC 0004: Three fixes for cover inconsistency - path normalization, auto-generate on ingest, app placeholder. See docs/rfcs/0004-cover-consistency.md. Approve to start implementation.