### PR TITLE
RFC: Semantic embedding search (multilingual)

### DIFF
--- a/docs/rfcs/0005-embedding-search.md
+++ b/docs/rfcs/0005-embedding-search.md
@@ -1,0 +1,151 @@
+# RFC 0005: Semantic Embedding Search
+
+**Issue**: #9  
+**Status**: Draft — awaiting approval  
+**Branch**: `rfc/issue-9-embedding-search`
+
+---
+
+## Problem
+
+Current search (`db.search()`) uses SQLite FTS5 with full-text matching. FTS5 has language-specific limitations:
+
+- **Tokenization is Latin-script biased** — Spanish accented characters (é, ñ, ü), Greek math symbols, and Cyrillic degrade match quality.
+- **No synonym matching** — searching "cálculo" won't match a document whose title is "Calculus".
+- **No semantic proximity** — "differential geometry" doesn't match "geometría diferencial" even though they're the same topic.
+- **No fuzzy matching** — a typo ("calculs") returns zero results.
+
+The issue notes "many bugs for different languages" as the core symptom.
+
+---
+
+## Proposed Solution
+
+Add **semantic embedding search** alongside the existing FTS5 search:
+
+1. At `wst topics build` time (when embeddings are already computed), **persist document embeddings** to a vector index on disk.
+2. At search time, embed the query with the same model and **retrieve top-K documents by cosine similarity**.
+3. Blend or replace the FTS5 results with embedding results depending on a `--mode` flag.
+
+### Architecture
+
+#### Step 1 — Persist embeddings
+
+During `build_vocabulary` (which already embeds all documents), save the embeddings to a binary file alongside the DB:
+
+```
+~/.wst/library/
+  wst.db
+  embeddings.npy        ← (n_docs, 384) float32 array
+  embeddings_ids.json   ← [doc_id, doc_id, ...] ordered parallel to rows
+```
+
+Or store in a dedicated SQLite table as BLOB for portability.
+
+**Implementation** (in `topics.py` or a new `search_index.py`):
+
+```python
+def save_embeddings(library_path: Path, doc_ids: list[int], embeddings: np.ndarray) -> None:
+    np.save(library_path / "embeddings.npy", embeddings.astype(np.float32))
+    (library_path / "embeddings_ids.json").write_text(json.dumps(doc_ids))
+
+def load_embeddings(library_path: Path) -> tuple[list[int], np.ndarray] | None:
+    emb_path = library_path / "embeddings.npy"
+    ids_path = library_path / "embeddings_ids.json"
+    if not emb_path.exists() or not ids_path.exists():
+        return None
+    ids = json.loads(ids_path.read_text())
+    emb = np.load(emb_path)
+    return ids, emb
+```
+
+#### Step 2 — Embed the query at search time
+
+```python
+def semantic_search(
+    library_path: Path,
+    db: Database,
+    query: str,
+    top_k: int = 20,
+) -> list[LibraryEntry]:
+    from sentence_transformers import SentenceTransformer
+    import numpy as np
+
+    data = load_embeddings(library_path)
+    if data is None:
+        return []   # fall back to FTS
+
+    doc_ids, embeddings = data
+    model = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
+    q_emb = model.encode([query])[0]
+
+    # Cosine similarity
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    sim = (embeddings / norms) @ (q_emb / np.linalg.norm(q_emb))
+    top_indices = np.argsort(sim)[::-1][:top_k]
+    ranked_ids = [doc_ids[i] for i in top_indices]
+
+    entries = db.get_by_ids(ranked_ids)
+    return sorted(entries, key=lambda e: ranked_ids.index(e.id))
+```
+
+#### Step 3 — Add `--mode` to `wst search`
+
+```
+wst search "cálculo" --mode fts       # existing behavior (default for now)
+wst search "cálculo" --mode semantic  # new embedding-based search
+wst search "cálculo" --mode hybrid    # union of both, deduplicated
+```
+
+**Default**: keep `fts` as default until embeddings are validated. Users who've run `wst topics build` get `semantic` as the default.
+
+### Model reuse
+
+The same `paraphrase-multilingual-MiniLM-L12-v2` model already used for topics clustering is reused here — no new models or dependencies.
+
+### Dependency
+
+Requires `sentence-transformers` (already in the `[topics]` optional group). Semantic search is only available if the user has installed the topics extras:
+
+```
+pip install 'wst-library[topics]'
+```
+
+Graceful fallback to FTS if sentence-transformers is unavailable.
+
+---
+
+## Incremental update
+
+When a new document is ingested, its embedding needs to be appended to `embeddings.npy`. Add a `update_embedding(library_path, doc_id, text)` function called from `ingest_file`:
+
+```python
+def update_embedding(library_path: Path, doc_id: int, text: str) -> None:
+    from sentence_transformers import SentenceTransformer
+    emb = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2").encode([text])[0]
+    # Append to .npy or rebuild from scratch if small corpus
+    ...
+```
+
+For simplicity (and because ingesting is rare), **rebuild the full index** on each ingest if it already exists. For large libraries (>1000 docs), incremental append would be better — defer to a follow-up.
+
+---
+
+## Open Questions
+
+> **Q1**: Should `semantic` become the default search mode once embeddings exist, or keep `fts` as default with `--semantic` flag?
+
+> **Q2**: How should we handle the app's search (which calls `wst search` via `run_wst_command`)? Should the app detect if embeddings exist and auto-use semantic mode?
+
+> **Q3**: Should we store embeddings in SQLite as BLOBs (single file, portable) or as `.npy` files (fast, simple, but extra files)? The corpus is small (<10k docs), so either is fine.
+
+> **Q4**: Should we auto-rebuild the embedding index after `wst ingest`, or keep it as an explicit `wst topics build` step?
+
+---
+
+## Files Changed (implementation phase)
+
+- `src/wst/topics.py` — save embeddings at the end of `build_vocabulary`
+- `src/wst/db.py` — add `get_by_ids(ids: list[int])` method
+- `src/wst/cli.py` — add `--mode` option to `wst search`; add `semantic_search` function or module
+- `src/wst/search.py` (new) — `semantic_search`, `save_embeddings`, `load_embeddings`

--- a/docs/rfcs/0005-embedding-search.md
+++ b/docs/rfcs/0005-embedding-search.md
@@ -1,151 +1,73 @@
-# RFC 0005: Semantic Embedding Search
+# RFC 0005: Semantic Embedding Search (multilingual)
 
 **Issue**: #9  
-**Status**: Draft — awaiting approval  
+**Status**: Approved — implementation in progress  
 **Branch**: `rfc/issue-9-embedding-search`
 
 ---
 
 ## Problem
 
-Current search (`db.search()`) uses SQLite FTS5 with full-text matching. FTS5 has language-specific limitations:
+Current search uses SQLite FTS5, which has language-specific limitations:
 
-- **Tokenization is Latin-script biased** — Spanish accented characters (é, ñ, ü), Greek math symbols, and Cyrillic degrade match quality.
-- **No synonym matching** — searching "cálculo" won't match a document whose title is "Calculus".
-- **No semantic proximity** — "differential geometry" doesn't match "geometría diferencial" even though they're the same topic.
-- **No fuzzy matching** — a typo ("calculs") returns zero results.
-
-The issue notes "many bugs for different languages" as the core symptom.
+- Tokenization is Latin-script biased — accented characters (é, ñ) degrade match quality.
+- No synonym matching — "cálculo" won't match a document titled "Calculus".
+- No semantic proximity — "differential geometry" doesn't match "geometría diferencial".
+- Typos return zero results.
 
 ---
 
-## Proposed Solution
+## Approved Solution
 
-Add **semantic embedding search** alongside the existing FTS5 search:
+Add semantic embedding search as the **default mode** when an index exists:
 
-1. At `wst topics build` time (when embeddings are already computed), **persist document embeddings** to a vector index on disk.
-2. At search time, embed the query with the same model and **retrieve top-K documents by cosine similarity**.
-3. Blend or replace the FTS5 results with embedding results depending on a `--mode` flag.
+1. `wst topics build` computes all document embeddings (already done) and persists them to a new `embeddings` SQLite table as BLOB columns.
+2. `wst search` detects if the index exists and uses cosine-similarity search by default; falls back to FTS if not.
+3. New documents added via `wst ingest` are automatically embedded and added to the index (if it already exists).
+4. `wst search --mode fts` forces FTS for users who need keyword-exact behavior.
 
-### Architecture
+### Approved answers
 
-#### Step 1 — Persist embeddings
+- **Q1**: Semantic is default when the index exists; `--mode fts` overrides.
+- **Q2**: App auto-uses semantic — since `wst search` auto-detects, `run_wst_command` requires no changes.
+- **Q3**: SQLite BLOBs — embeddings stored in `embeddings` table, single file, portable.
+- **Q4**: Incremental — after `wst ingest`, the new doc is added to the existing index automatically.
 
-During `build_vocabulary` (which already embeds all documents), save the embeddings to a binary file alongside the DB:
+### Storage: `embeddings` table
 
-```
-~/.wst/library/
-  wst.db
-  embeddings.npy        ← (n_docs, 384) float32 array
-  embeddings_ids.json   ← [doc_id, doc_id, ...] ordered parallel to rows
-```
-
-Or store in a dedicated SQLite table as BLOB for portability.
-
-**Implementation** (in `topics.py` or a new `search_index.py`):
-
-```python
-def save_embeddings(library_path: Path, doc_ids: list[int], embeddings: np.ndarray) -> None:
-    np.save(library_path / "embeddings.npy", embeddings.astype(np.float32))
-    (library_path / "embeddings_ids.json").write_text(json.dumps(doc_ids))
-
-def load_embeddings(library_path: Path) -> tuple[list[int], np.ndarray] | None:
-    emb_path = library_path / "embeddings.npy"
-    ids_path = library_path / "embeddings_ids.json"
-    if not emb_path.exists() or not ids_path.exists():
-        return None
-    ids = json.loads(ids_path.read_text())
-    emb = np.load(emb_path)
-    return ids, emb
+```sql
+CREATE TABLE IF NOT EXISTS embeddings (
+    doc_id INTEGER PRIMARY KEY REFERENCES documents(id) ON DELETE CASCADE,
+    embedding BLOB NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 ```
 
-#### Step 2 — Embed the query at search time
+Each embedding is a `float32` numpy array serialized via `.tobytes()` (~1.5 KB per doc for 384-dim). `ON DELETE CASCADE` keeps the index clean when documents are deleted.
 
-```python
-def semantic_search(
-    library_path: Path,
-    db: Database,
-    query: str,
-    top_k: int = 20,
-) -> list[LibraryEntry]:
-    from sentence_transformers import SentenceTransformer
-    import numpy as np
-
-    data = load_embeddings(library_path)
-    if data is None:
-        return []   # fall back to FTS
-
-    doc_ids, embeddings = data
-    model = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
-    q_emb = model.encode([query])[0]
-
-    # Cosine similarity
-    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
-    sim = (embeddings / norms) @ (q_emb / np.linalg.norm(q_emb))
-    top_indices = np.argsort(sim)[::-1][:top_k]
-    ranked_ids = [doc_ids[i] for i in top_indices]
-
-    entries = db.get_by_ids(ranked_ids)
-    return sorted(entries, key=lambda e: ranked_ids.index(e.id))
-```
-
-#### Step 3 — Add `--mode` to `wst search`
+### Search flow
 
 ```
-wst search "cálculo" --mode fts       # existing behavior (default for now)
-wst search "cálculo" --mode semantic  # new embedding-based search
-wst search "cálculo" --mode hybrid    # union of both, deduplicated
+wst search "cálculo diferencial"
+  └─ mode == "auto" AND query non-empty AND db.count_embeddings() > 0?
+       yes → semantic search
+               → embed query with SentenceTransformer (multilingual)
+               → cosine similarity over all stored embeddings
+               → apply field filters (--type, --author, etc.) in memory
+               → return ranked LibraryEntry list
+       no  → db.search() FTS fallback (existing behavior)
 ```
 
-**Default**: keep `fts` as default until embeddings are validated. Users who've run `wst topics build` get `semantic` as the default.
+### Reuse existing model
 
-### Model reuse
-
-The same `paraphrase-multilingual-MiniLM-L12-v2` model already used for topics clustering is reused here — no new models or dependencies.
-
-### Dependency
-
-Requires `sentence-transformers` (already in the `[topics]` optional group). Semantic search is only available if the user has installed the topics extras:
-
-```
-pip install 'wst-library[topics]'
-```
-
-Graceful fallback to FTS if sentence-transformers is unavailable.
+`paraphrase-multilingual-MiniLM-L12-v2` (already in `[topics]` extras) is reused — no new dependencies.
 
 ---
 
-## Incremental update
+## Files Changed
 
-When a new document is ingested, its embedding needs to be appended to `embeddings.npy`. Add a `update_embedding(library_path, doc_id, text)` function called from `ingest_file`:
-
-```python
-def update_embedding(library_path: Path, doc_id: int, text: str) -> None:
-    from sentence_transformers import SentenceTransformer
-    emb = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2").encode([text])[0]
-    # Append to .npy or rebuild from scratch if small corpus
-    ...
-```
-
-For simplicity (and because ingesting is rare), **rebuild the full index** on each ingest if it already exists. For large libraries (>1000 docs), incremental append would be better — defer to a follow-up.
-
----
-
-## Open Questions
-
-> **Q1**: Should `semantic` become the default search mode once embeddings exist, or keep `fts` as default with `--semantic` flag?
-
-> **Q2**: How should we handle the app's search (which calls `wst search` via `run_wst_command`)? Should the app detect if embeddings exist and auto-use semantic mode?
-
-> **Q3**: Should we store embeddings in SQLite as BLOBs (single file, portable) or as `.npy` files (fast, simple, but extra files)? The corpus is small (<10k docs), so either is fine.
-
-> **Q4**: Should we auto-rebuild the embedding index after `wst ingest`, or keep it as an explicit `wst topics build` step?
-
----
-
-## Files Changed (implementation phase)
-
-- `src/wst/topics.py` — save embeddings at the end of `build_vocabulary`
-- `src/wst/db.py` — add `get_by_ids(ids: list[int])` method
-- `src/wst/cli.py` — add `--mode` option to `wst search`; add `semantic_search` function or module
-- `src/wst/search.py` (new) — `semantic_search`, `save_embeddings`, `load_embeddings`
+- `src/wst/search.py` (new) — `build_index`, `build_index_from_embeddings`, `upsert_entry`, `search`
+- `src/wst/db.py` — add `embeddings` table with FK cascade, enable FK enforcement, `upsert_embedding`, `load_all_embeddings`, `count_embeddings`, `get_by_ids`
+- `src/wst/topics.py` — save embeddings to DB at the end of `build_vocabulary`
+- `src/wst/ingest.py` — call `search.upsert_entry` after inserting a new document
+- `src/wst/cli.py` — add `--mode auto|fts|semantic` to `wst search`; route through semantic when index exists

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -735,6 +735,15 @@ def _copy_to_inbox(source: Path, inbox: Path) -> list[Path]:
 @click.option("--type", "-t", "doc_type", default=None, help="Filter by document type")
 @click.option("--subject", "-s", default=None, help="Filter by subject/knowledge area")
 @click.option("--topic", "-p", default=None, help="Filter by topic (partial, case-insensitive)")
+@click.option(
+    "--mode",
+    type=click.Choice(["auto", "fts", "semantic"], case_sensitive=False),
+    default="auto",
+    help=(
+        "Search mode: auto (semantic when index exists, else FTS), "
+        "fts (keyword), semantic (embedding-based)"
+    ),
+)
 @click.pass_context
 def search(
     ctx: click.Context,
@@ -743,14 +752,24 @@ def search(
     doc_type: str | None,
     subject: str | None,
     topic: str | None,
+    mode: str,
 ) -> None:
-    """Search documents by title, author, tags, subject, or topic."""
+    """Search documents by title, author, tags, subject, or topic.
+
+    \b
+    Semantic search (default when index exists):
+        wst search "machine learning"         # auto-uses semantic if index built
+        wst search "machine learning" --mode semantic
+        wst search "machine learning" --mode fts   # force keyword search
+    """
     config: WstConfig = ctx.obj["config"]
     fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
-        results = db.search(query, doc_type=doc_type, author=author, subject=subject, topic=topic)
+        results = _run_search(
+            db, query, mode=mode, doc_type=doc_type, author=author, subject=subject, topic=topic
+        )
         if not results:
             if fmt == "human":
                 click.echo("No results found.")
@@ -767,6 +786,47 @@ def search(
         render_ok(results, fmt=fmt)
     finally:
         db.close()
+
+
+def _run_search(
+    db: Database,
+    query: str,
+    *,
+    mode: str = "auto",
+    doc_type: str | None = None,
+    author: str | None = None,
+    subject: str | None = None,
+    topic: str | None = None,
+) -> list:
+    """Route search through semantic or FTS depending on mode and index availability."""
+    use_semantic = False
+    if query and mode in ("auto", "semantic"):
+        from wst.search import search as _semantic_search
+
+        sem_results = _semantic_search(db, query, top_k=50)
+        if sem_results is not None:
+            use_semantic = True
+            results = sem_results
+            # Apply field filters in-memory (semantic bypasses SQL WHERE)
+            if doc_type:
+                results = [r for r in results if r.metadata.doc_type.value == doc_type.lower()]
+            if author:
+                results = [
+                    r for r in results if author.lower() in (r.metadata.author or "").lower()
+                ]
+            if subject:
+                results = [
+                    r for r in results if subject.lower() in (r.metadata.subject or "").lower()
+                ]
+            if topic:
+                results = [
+                    r for r in results if any(topic.lower() in t.lower() for t in r.metadata.topics)
+                ]
+            return results
+
+    if not use_semantic:
+        return db.search(query, doc_type=doc_type, author=author, subject=subject, topic=topic)
+    return []
 
 
 @cli.command(name="list")

--- a/src/wst/db.py
+++ b/src/wst/db.py
@@ -60,6 +60,14 @@ CREATE TABLE IF NOT EXISTS topics_vocabulary (
 );
 """
 
+EMBEDDINGS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS embeddings (
+    doc_id     INTEGER PRIMARY KEY REFERENCES documents(id) ON DELETE CASCADE,
+    embedding  BLOB NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
 
 def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
     rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
@@ -85,6 +93,7 @@ class Database:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(str(db_path))
         self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA foreign_keys = ON")
         self._init_schema()
 
     def _init_schema(self) -> None:
@@ -101,6 +110,7 @@ class Database:
             self.conn.executescript(FTS_SCHEMA)
 
         self.conn.executescript(TOPICS_VOCABULARY_SCHEMA)
+        self.conn.executescript(EMBEDDINGS_SCHEMA)
 
     def _rebuild_fts(self) -> None:
         """Drop and recreate FTS table with the current schema, then repopulate."""
@@ -330,6 +340,35 @@ class Database:
         if row is None:
             return None
         return json.loads(row["topics"])
+
+    # ------------------------------------------------------------------
+    # Embeddings (semantic search index)
+    # ------------------------------------------------------------------
+
+    def upsert_embedding(self, doc_id: int, embedding_bytes: bytes) -> None:
+        self.conn.execute(
+            "INSERT OR REPLACE INTO embeddings(doc_id, embedding, updated_at)"
+            " VALUES (?, ?, datetime('now'))",
+            (doc_id, embedding_bytes),
+        )
+        self.conn.commit()
+
+    def load_all_embeddings(self) -> dict[int, bytes]:
+        rows = self.conn.execute("SELECT doc_id, embedding FROM embeddings").fetchall()
+        return {row["doc_id"]: bytes(row["embedding"]) for row in rows}
+
+    def count_embeddings(self) -> int:
+        row = self.conn.execute("SELECT COUNT(*) AS n FROM embeddings").fetchone()
+        return row["n"] if row else 0
+
+    def get_by_ids(self, doc_ids: list[int]) -> list[LibraryEntry]:
+        if not doc_ids:
+            return []
+        placeholders = ",".join("?" * len(doc_ids))
+        rows = self.conn.execute(
+            f"SELECT * FROM documents WHERE id IN ({placeholders})", doc_ids
+        ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
 
     def _row_to_entry(self, row: sqlite3.Row) -> LibraryEntry:
         tags = json.loads(row["tags"]) if row["tags"] else []

--- a/src/wst/ingest.py
+++ b/src/wst/ingest.py
@@ -175,6 +175,12 @@ def ingest_file(
 
     # Index in DB
     entry.id = db.insert(entry)
+
+    # Update semantic search index if it already exists
+    from wst.search import upsert_entry as _upsert_embedding
+
+    _upsert_embedding(db, entry)
+
     if verbose:
         click.echo(f"  Ingested -> {final_path}")
     return IngestResult(path.name, "ingested", dest_path=final_path)

--- a/src/wst/search.py
+++ b/src/wst/search.py
@@ -1,0 +1,117 @@
+"""Semantic search via sentence embeddings stored in SQLite."""
+
+from __future__ import annotations
+
+from wst.db import Database
+from wst.models import LibraryEntry
+
+_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
+
+
+def _entry_text(entry: LibraryEntry) -> str:
+    m = entry.metadata
+    parts = [m.title]
+    if m.tags:
+        parts.append(", ".join(m.tags))
+    if m.summary:
+        parts.append(m.summary[:300])
+    return " | ".join(parts)
+
+
+def build_index(db: Database, entries: list[LibraryEntry]) -> int:
+    """Embed all entries and persist to the DB embeddings table.
+
+    Returns the number of embeddings stored, or 0 if sentence-transformers
+    is not available.
+    """
+    try:
+        import numpy as np
+        from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]
+    except (ImportError, OSError):
+        return 0
+
+    model = SentenceTransformer(_MODEL_NAME)
+    texts = [_entry_text(e) for e in entries]
+    embeddings = model.encode(texts, show_progress_bar=False)
+    for entry, emb in zip(entries, embeddings):
+        db.upsert_embedding(entry.id, emb.astype(np.float32).tobytes())
+    return len(entries)
+
+
+def build_index_from_embeddings(
+    db: Database,
+    doc_metas: list[dict],
+    embeddings,
+) -> None:
+    """Persist pre-computed numpy embeddings from topics build.
+
+    Called from topics.build_vocabulary() to avoid re-embedding.
+    doc_metas must have an 'id' key for each row.
+    """
+    import numpy as np
+
+    for meta, emb in zip(doc_metas, embeddings):
+        db.upsert_embedding(meta["id"], emb.astype(np.float32).tobytes())
+
+
+def upsert_entry(db: Database, entry: LibraryEntry) -> None:
+    """Compute and store/update the embedding for a single entry.
+
+    No-op if the index is empty (not yet built) or if sentence-transformers
+    is not installed — callers should not fail on this.
+    """
+    if db.count_embeddings() == 0:
+        return
+    try:
+        import numpy as np
+        from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]
+    except (ImportError, OSError):
+        return
+
+    model = SentenceTransformer(_MODEL_NAME)
+    emb = model.encode([_entry_text(entry)], show_progress_bar=False)[0]
+    db.upsert_embedding(entry.id, emb.astype(np.float32).tobytes())
+
+
+def search(
+    db: Database,
+    query: str,
+    top_k: int = 50,
+) -> list[LibraryEntry] | None:
+    """Semantic search over the embedding index.
+
+    Returns a ranked list of LibraryEntry objects, or None when:
+    - the index is empty (caller should fall back to FTS), or
+    - sentence-transformers is not installed.
+    """
+    if db.count_embeddings() == 0:
+        return None
+
+    try:
+        import numpy as np
+        from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]
+    except (ImportError, OSError):
+        return None
+
+    all_embs = db.load_all_embeddings()
+    if not all_embs:
+        return None
+
+    doc_ids = list(all_embs.keys())
+    emb_matrix = np.stack([np.frombuffer(all_embs[d], dtype=np.float32) for d in doc_ids])
+
+    model = SentenceTransformer(_MODEL_NAME)
+    q_emb = model.encode([query], show_progress_bar=False)[0]
+
+    q_norm = float(np.linalg.norm(q_emb))
+    if q_norm == 0:
+        return None
+
+    norms = np.linalg.norm(emb_matrix, axis=1, keepdims=True)
+    sim = (emb_matrix / (norms + 1e-10)) @ (q_emb / q_norm)
+    top_indices = np.argsort(sim)[::-1][:top_k]
+    ranked_ids = [doc_ids[i] for i in top_indices]
+
+    entries = db.get_by_ids(ranked_ids)
+    id_to_entry = {e.id: e for e in entries}
+    return [id_to_entry[i] for i in ranked_ids if i in id_to_entry]

--- a/src/wst/topics.py
+++ b/src/wst/topics.py
@@ -171,6 +171,9 @@ def build_vocabulary(
     if n_docs < 2:
         # Can't cluster a single document — just name it directly
         topic = _name_cluster(ai_backend, doc_metas[:1])
+        from wst.search import build_index_from_embeddings
+
+        build_index_from_embeddings(db, doc_metas, embeddings)
         representative_docs = {0: [doc_metas[0]["title"]]}
         return [topic], representative_docs
 
@@ -215,6 +218,11 @@ def build_vocabulary(
 
     # Resolve duplicate names (e.g. two clusters both named "Álgebra Lineal")
     _deduplicate_vocabulary(ai_backend, vocabulary, cluster_docs_map)
+
+    # Persist embeddings for semantic search (reuse already-computed array)
+    from wst.search import build_index_from_embeddings
+
+    build_index_from_embeddings(db, doc_metas, embeddings)
 
     return vocabulary, representative_docs
 


### PR DESCRIPTION
Closes #9

RFC 0005: Replace FTS5 keyword search with multilingual semantic embedding search using the same sentence-transformer model already used for topics clustering. Adds --mode flag (fts/semantic/hybrid). No new dependencies required for topics users.

See docs/rfcs/0005-embedding-search.md for full design. Approve to start implementation.