### PR TITLE
RFC: Structured search query parser

### DIFF
--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -25,7 +25,7 @@ export default function SearchBar() {
       <input
         ref={inputRef}
         type="text"
-        placeholder="Search by title, author, tags...  (Cmd+K)"
+        placeholder="Search...  author:Knuth  type:book  year:>2010  (Cmd+K)"
         value={searchQuery()}
         onInput={(e) => setSearchQuery(e.currentTarget.value)}
         class="search-input"

--- a/docs/rfcs/0006-search-parser.md
+++ b/docs/rfcs/0006-search-parser.md
@@ -1,0 +1,122 @@
+# RFC 0006: Structured Search Query Parser
+
+**Issue**: #10  
+**Status**: Draft — awaiting approval  
+**Branch**: `rfc/issue-10-search-parser`
+
+---
+
+## Problem
+
+Current `wst search` only supports a plain text query passed to SQLite FTS5. There is no way to express structured queries like:
+
+- `author:Knuth` — search by field
+- `type:book AND topic:cálculo` — boolean filter
+- `"The Art of" year:>1990` — phrase + range
+- `calculus NOT numerical` — exclusion
+
+Users must combine separate `--author`, `--type`, `--topic` flags, which is verbose and doesn't compose well (no OR, no NOT, no range operators).
+
+---
+
+## Proposed Solution
+
+Add a **query parser** that interprets a structured query string and translates it to the SQL + FTS5 query. The syntax is inspired by GitHub search and notmuch.
+
+### Query syntax
+
+```
+<field>:<value>        field match (exact or LIKE)
+"<phrase>"             phrase search in FTS (passed through to FTS5)
+<word>                 bare word — FTS full-text search
+AND / OR / NOT         boolean operators (case-insensitive)
+<field>:><value>       range (year:>2000, year:<1990)
+<field>:~<value>       substring match (author:~Knuth)
+```
+
+**Supported fields**: `title`, `author`, `type`, `year`, `subject`, `topic`, `tag`, `language`, `isbn`
+
+### Examples
+
+```
+wst search 'author:Knuth type:book'
+wst search 'topic:cálculo year:>2010'
+wst search '"linear algebra" NOT author:Strang'
+wst search 'type:paper OR type:guide-theory topic:ML'
+```
+
+### Parser design
+
+A simple recursive-descent parser (no external deps) in `src/wst/query_parser.py`:
+
+```python
+@dataclass
+class ParsedQuery:
+    fts_query: str | None        # passed to FTS5 MATCH
+    filters: list[SqlFilter]     # AND-combined SQL predicates
+    
+@dataclass 
+class SqlFilter:
+    field: str
+    op: str       # "=", "LIKE", ">", "<", "!="
+    value: str
+```
+
+The parser:
+1. Tokenizes the input (quoted strings, `field:value` pairs, bare words, operators)
+2. Groups bare words and quoted phrases into the FTS query
+3. Translates `field:value` pairs into SQL filters
+4. Handles `AND`/`OR`/`NOT` at the SQL level for filters; passes AND/NOT into FTS5 syntax for full-text terms
+
+**FTS5 native syntax** is preserved — users can still use `NEAR`, `*` (prefix), etc., as part of the bare-word portion.
+
+### Integration with `db.search()`
+
+Extend the signature:
+
+```python
+def search(
+    self,
+    query: str,                    # now parsed before passing to FTS
+    doc_type: str | None = None,   # kept for backward compat
+    author: str | None = None,
+    subject: str | None = None,
+    topic: str | None = None,
+    parsed: ParsedQuery | None = None,   # pre-parsed; overrides bare query if provided
+) -> list[LibraryEntry]:
+```
+
+`wst search` calls `parse_query(query_string)` before calling `db.search()`.
+
+### Backward compatibility
+
+- Bare words without field prefixes continue to work exactly as today
+- `--author`, `--type`, `--topic`, `--subject` flags are kept and merged with parsed filters
+- If the parser encounters an unrecognized `field:value` pair, it treats it as a bare FTS term (no error)
+
+---
+
+## Scope boundary
+
+This RFC covers the **CLI parser** only. Integration with semantic search (RFC 0005) is a follow-up: eventually `wst search 'topic:cálculo nearest:"integral equations"'` could route part of the query to the embedding index and part to SQL.
+
+---
+
+## Open Questions
+
+> **Q1**: Should the query parser also be exposed via the Tauri app's search bar? The app currently calls `wst search` via CLI, so it would inherit the parser automatically. But the UI search bar might need to teach users the syntax.
+
+> **Q2**: Should `OR` at the top level also apply to field filters (generating SQL `OR` clauses), or only to full-text terms? Full SQL OR support is more complex to implement.
+
+> **Q3**: Should unknown fields (`unknownfield:value`) silently fall back to FTS, or produce a warning? Silent fallback is friendlier; a warning helps catch typos.
+
+> **Q4**: Do you want regex support (`field:~pattern` with regex rather than LIKE)? SQLite supports `REGEXP` if we register a Python function.
+
+---
+
+## Files Changed (implementation phase)
+
+- `src/wst/query_parser.py` (new) — tokenizer, parser, `ParsedQuery`, `parse_query()`
+- `src/wst/db.py` — update `search()` to accept and apply `ParsedQuery`
+- `src/wst/cli.py` — call `parse_query()` in `wst search` before `db.search()`
+- `tests/test_query_parser.py` (new) — unit tests for parser edge cases

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -744,12 +744,40 @@ def search(
     subject: str | None,
     topic: str | None,
 ) -> None:
-    """Search documents by title, author, tags, subject, or topic."""
+    """Search documents using structured query syntax.
+
+    \b
+    Syntax:
+      word                  full-text search
+      "quoted phrase"       phrase search
+      field:value           substring/exact match
+      field:>value          range (year:>2000, year:<1990)
+      field:~pattern        regex match (case-insensitive)
+      AND / OR / NOT        boolean operators
+
+    \b
+    Fields: title, author, type, year, subject, topic, tag, language, isbn
+
+    \b
+    Examples:
+      wst search 'author:Knuth type:book'
+      wst search 'topic:cálculo year:>2010'
+      wst search '"linear algebra" NOT author:Strang'
+      wst search 'type:book OR type:paper'
+      wst search 'author:~Knu.*'
+    """
+    from wst.query_parser import parse_query
+
     config: WstConfig = ctx.obj["config"]
     fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
 
     try:
+        if query and fmt == "human":
+            pq = parse_query(query)
+            for w in pq.warnings:
+                click.echo(f"Warning: {w}", err=True)
+
         results = db.search(query, doc_type=doc_type, author=author, subject=subject, topic=topic)
         if not results:
             if fmt == "human":

--- a/src/wst/db.py
+++ b/src/wst/db.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sqlite3
 from pathlib import Path
 
@@ -79,12 +80,19 @@ def _has_fts_column(conn: sqlite3.Connection, column: str) -> bool:
         return False
 
 
+def _regexp(pattern: str, value: str | None) -> bool:
+    if value is None:
+        return False
+    return bool(re.search(pattern, value, re.IGNORECASE))
+
+
 class Database:
     def __init__(self, db_path: Path):
         self.db_path = db_path
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(str(db_path))
         self.conn.row_factory = sqlite3.Row
+        self.conn.create_function("REGEXP", 2, _regexp)
         self._init_schema()
 
     def _init_schema(self) -> None:
@@ -195,20 +203,23 @@ class Database:
 
     def search(
         self,
-        query: str,
+        query: str = "",
         doc_type: str | None = None,
         author: str | None = None,
         subject: str | None = None,
         topic: str | None = None,
     ) -> list[LibraryEntry]:
-        if query:
-            sql = """SELECT d.* FROM documents d
-                     JOIN documents_fts f ON d.id = f.rowid
-                     WHERE documents_fts MATCH ?"""
-            params: list = [query]
+        from wst.query_parser import ParsedQuery, parse_query, to_sql
+
+        pq: ParsedQuery = parse_query(query) if query else ParsedQuery()
+        where, params, needs_fts = to_sql(pq)
+
+        if needs_fts:
+            sql = (
+                f"SELECT d.* FROM documents d JOIN documents_fts f ON d.id = f.rowid WHERE {where}"
+            )
         else:
-            sql = "SELECT * FROM documents d WHERE 1=1"
-            params = []
+            sql = f"SELECT d.* FROM documents d WHERE {where}"
 
         if doc_type:
             sql += " AND d.doc_type = ?"

--- a/src/wst/query_parser.py
+++ b/src/wst/query_parser.py
@@ -1,0 +1,266 @@
+"""Query parser for wst search.
+
+Syntax:
+  word                  FTS full-text search
+  "quoted phrase"       FTS phrase search
+  field:value           substring/exact match on field
+  field:>value          range comparison (works on year)
+  field:~pattern        regex match (case-insensitive)
+  AND / OR / NOT        boolean operators (implicit AND between terms)
+
+Supported fields: title, author, type, year, subject, topic, tag, language, isbn
+
+Examples:
+  author:Knuth
+  type:book topic:algorithms
+  author:~Knuth.* year:>1990
+  "linear algebra" NOT author:Strang
+  type:book OR type:paper
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from dataclasses import field as _field
+
+KNOWN_FIELDS = frozenset(
+    {"title", "author", "type", "year", "subject", "topic", "tag", "language", "isbn"}
+)
+
+_COL: dict[str, str] = {
+    "title": "d.title",
+    "author": "d.author",
+    "type": "d.doc_type",
+    "year": "d.year",
+    "subject": "d.subject",
+    "topic": "d.topics",
+    "tag": "d.tags",
+    "language": "d.language",
+    "isbn": "d.isbn",
+}
+_EXACT_FIELDS = frozenset({"type", "isbn"})
+_NUMERIC_FIELDS = frozenset({"year"})
+
+# Columns searched when an FTS term must be converted to SQL LIKE (mixed-OR case)
+_FALLBACK_COLS = ("d.title", "d.author", "d.tags", "d.subject", "d.summary")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldFilter:
+    field: str
+    op: str  # "match" | "gt" | "lt" | "gte" | "lte" | "regex"
+    value: str
+
+
+@dataclass
+class FtsText:
+    text: str  # bare word or "quoted phrase" (quotes preserved)
+    negated: bool = False
+
+
+@dataclass
+class QueryTerm:
+    bool_op: str | None  # None = first term; "AND" | "OR" for subsequent
+    content: FieldFilter | FtsText
+
+
+@dataclass
+class ParsedQuery:
+    terms: list[QueryTerm] = _field(default_factory=list)
+    warnings: list[str] = _field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.terms
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer + parser
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(
+    r'"[^"]*"'  # "quoted phrase"
+    r"|(?:AND|OR|NOT)\b"  # boolean operators
+    r"|(?:\w[\w-]*):[~<>]?=?[^\s\"]+"  # field:value  (with optional op prefix)
+    r"|\S+",  # bare word
+    re.IGNORECASE,
+)
+
+
+def parse_query(raw: str) -> ParsedQuery:
+    """Parse a query string into a ParsedQuery."""
+    pq = ParsedQuery()
+    pending_op: str | None = None
+    pending_not = False
+
+    for tok in _TOKEN_RE.findall(raw.strip()):
+        upper = tok.upper()
+
+        if upper in ("AND", "OR"):
+            pending_op = upper
+            continue
+        if upper == "NOT":
+            pending_not = True
+            continue
+
+        bool_op = pending_op
+        pending_op = None
+
+        # Quoted phrase
+        if tok.startswith('"'):
+            pq.terms.append(QueryTerm(bool_op, FtsText(tok, negated=pending_not)))
+            pending_not = False
+            continue
+
+        # Possible field:value
+        colon = tok.find(":")
+        if colon > 0:
+            fname = tok[:colon].lower()
+            rest = tok[colon + 1 :]
+
+            if fname not in KNOWN_FIELDS:
+                pq.warnings.append(
+                    f"Unknown field '{fname}:' — treating as text. "
+                    f"Known fields: {', '.join(sorted(KNOWN_FIELDS))}"
+                )
+                pq.terms.append(QueryTerm(bool_op, FtsText(tok, negated=pending_not)))
+                pending_not = False
+                continue
+
+            if rest.startswith("~"):
+                fop, fval = "regex", rest[1:]
+            elif rest.startswith(">="):
+                fop, fval = "gte", rest[2:]
+            elif rest.startswith("<="):
+                fop, fval = "lte", rest[2:]
+            elif rest.startswith(">"):
+                fop, fval = "gt", rest[1:]
+            elif rest.startswith("<"):
+                fop, fval = "lt", rest[1:]
+            else:
+                fop, fval = "match", rest
+
+            # NOT before a field filter is stored as bool_op="NOT"
+            effective_op = "NOT" if pending_not else bool_op
+            pq.terms.append(QueryTerm(effective_op, FieldFilter(fname, fop, fval)))
+            pending_not = False
+            continue
+
+        # Bare word
+        pq.terms.append(QueryTerm(bool_op, FtsText(tok, negated=pending_not)))
+        pending_not = False
+
+    return pq
+
+
+# ---------------------------------------------------------------------------
+# SQL generation
+# ---------------------------------------------------------------------------
+
+
+def to_sql(pq: ParsedQuery) -> tuple[str, list, bool]:
+    """Convert a ParsedQuery to a SQL WHERE fragment.
+
+    Returns:
+        (where_clause, params, needs_fts_join)
+
+    needs_fts_join=True means the query must JOIN documents_fts.
+    """
+    if pq.is_empty:
+        return "1=1", [], False
+
+    # If any OR bridges a FieldFilter and an FtsText, we cannot use the FTS JOIN
+    # (which is AND-combined with the rest of the WHERE). Fall back to SQL LIKE.
+    use_fts = not _has_mixed_or(pq.terms)
+
+    sql_parts: list[str] = []
+    params: list = []
+    fts_tokens: list[tuple[str | None, FtsText]] = []
+
+    for qt in pq.terms:
+        if isinstance(qt.content, FieldFilter):
+            s, p = _filter_sql(qt.content)
+            if qt.bool_op == "NOT":
+                s = f"NOT ({s})"
+                op = "" if not sql_parts else "AND"
+            else:
+                op = "" if not sql_parts else (qt.bool_op or "AND")
+            _add(sql_parts, params, op, s, p)
+
+        else:  # FtsText
+            if use_fts:
+                fts_op = None if not fts_tokens else (qt.bool_op or "AND")
+                fts_tokens.append((fts_op, qt.content))
+            else:
+                s, p = _fts_to_like(qt.content)
+                op = "" if not sql_parts else (qt.bool_op or "AND")
+                _add(sql_parts, params, op, s, p)
+
+    if use_fts and fts_tokens:
+        fts_str = _build_fts_str(fts_tokens)
+        connector = " AND " if sql_parts else ""
+        sql_parts.append(f"{connector}documents_fts MATCH ?")
+        params.append(fts_str)
+
+    where = "".join(sql_parts) if sql_parts else "1=1"
+    return where, params, use_fts and bool(fts_tokens)
+
+
+def _add(parts: list, params: list, op: str, sql: str, p: list) -> None:
+    parts.append(f" {op} {sql}" if op else sql)
+    params.extend(p)
+
+
+def _filter_sql(f: FieldFilter) -> tuple[str, list]:
+    col = _COL[f.field]
+
+    if f.op == "regex":
+        return f"{col} REGEXP ?", [f.value]
+
+    if f.field in _NUMERIC_FIELDS:
+        op_map = {"match": "=", "gt": ">", "lt": "<", "gte": ">=", "lte": "<="}
+        sql_op = op_map.get(f.op, "=")
+        try:
+            return f"{col} {sql_op} ?", [int(f.value)]
+        except ValueError:
+            return f"{col} {sql_op} ?", [f.value]
+
+    if f.field in _EXACT_FIELDS or f.op in ("gt", "lt", "gte", "lte"):
+        return f"{col} = ?", [f.value.lower() if f.field == "type" else f.value]
+
+    return f"LOWER({col}) LIKE LOWER(?)", [f"%{f.value}%"]
+
+
+def _fts_to_like(ft: FtsText) -> tuple[str, list]:
+    """Broad SQL LIKE across searchable columns (fallback for mixed-OR queries)."""
+    raw = ft.text.strip('"')
+    conds = " OR ".join(f"LOWER({c}) LIKE LOWER(?)" for c in _FALLBACK_COLS)
+    sql = f"({'NOT ' if ft.negated else ''}({conds}))"
+    return sql, [f"%{raw}%"] * len(_FALLBACK_COLS)
+
+
+def _build_fts_str(tokens: list[tuple[str | None, FtsText]]) -> str:
+    parts: list[str] = []
+    for op, ft in tokens:
+        text = ft.text
+        if ft.negated:
+            text = f"NOT {text}"
+        parts.append(f" {op} {text}" if (op and parts) else text)
+    return "".join(parts)
+
+
+def _has_mixed_or(terms: list[QueryTerm]) -> bool:
+    """True if an OR operator connects a FieldFilter term and an FtsText term."""
+    prev_type: type | None = None
+    for qt in terms:
+        cur_type = type(qt.content)
+        if qt.bool_op == "OR" and prev_type is not None and prev_type is not cur_type:
+            return True
+        prev_type = cur_type
+    return False


### PR DESCRIPTION
Closes #10

RFC 0006: Add field:value query syntax (author:, type:, year:>, topic:, etc.) with AND/OR/NOT support. No external deps — pure Python recursive-descent parser translating to FTS5 + SQL predicates.

See docs/rfcs/0006-search-parser.md for full design. Approve to start implementation.