### PR TITLE
RFC: Soporte multiplataforma (Windows + Linux releases)

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,7 +1,8 @@
 # Push an annotated tag 'vX.Y.Z' (matching pyproject.toml) to trigger:
-# tests, PyPI publish, .dmg build, optional Chocolatey push, and a GitHub
-# Release with all artifacts attached. Tags are normally pushed by
-# auto-release.yml; manual tag pushes work as an emergency-hotfix path.
+# tests, PyPI publish, .dmg + .exe + .AppImage + .deb builds, optional
+# Chocolatey push, and a GitHub Release with all artifacts attached.
+# Tags are normally pushed by auto-release.yml; manual tag pushes work
+# as an emergency-hotfix path.
 
 name: Release on tag
 
@@ -39,15 +40,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: python-dist
-          path: dist/
+          path: release-artifacts
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-dmg
-          path: dmg/
+      - name: Flatten artifact directories
+        run: |
+          mkdir -p flat
+          find release-artifacts -type f -exec cp {} flat/ \;
+          ls -la flat/
 
       - name: Create GitHub release with artifacts
         uses: softprops/action-gh-release@v2
@@ -55,6 +57,12 @@ jobs:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
           files: |
-            dist/*.whl
-            dist/*.tar.gz
-            dmg/*.dmg
+            flat/*.whl
+            flat/*.tar.gz
+            flat/*.dmg
+            flat/*.exe
+            flat/*.AppImage
+            flat/*.deb
+            flat/wst-macos
+            flat/wst-linux-x86_64
+            flat/wst.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 # Reusable build/publish pipeline called by release-on-tag.yml. Builds the
-# Python wheel + sdist, the macOS .dmg (with PyInstaller CLI sidecar bundling
-# numpy/sklearn/scipy), and pushes to PyPI + Chocolatey. Each job uploads
-# its artifacts; release-on-tag.yml's github-release job collects and attaches.
+# Python wheel + sdist plus per-platform CLI binaries and GUI installers
+# (macOS .dmg, Windows .exe, Linux .AppImage + .deb). Each job uploads its
+# artifacts; release-on-tag.yml's github-release job collects and attaches.
 
 on:
   workflow_call:
@@ -81,6 +81,9 @@ jobs:
           cp dist/wst "app/src-tauri/binaries/wst-$TRIPLE"
           chmod +x "app/src-tauri/binaries/wst-$TRIPLE"
 
+      - name: Rename CLI for upload (platform-tagged)
+        run: cp dist/wst dist/wst-macos
+
       - name: Build Tauri app
         run: cd app && npm ci && npx tauri build
         env:
@@ -95,8 +98,139 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: macos-cli
+          path: dist/wst-macos
+
+      - uses: actions/upload-artifact@v4
+        with:
           name: macos-dmg
           path: ${{ steps.dmg.outputs.path }}
+
+  windows-installer:
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build standalone wst CLI binary
+        shell: pwsh
+        run: |
+          python -m venv .venv
+          .venv\Scripts\pip install -e . numpy scikit-learn scipy pyinstaller
+          .venv\Scripts\pyinstaller --onefile --name wst `
+            --collect-all wst `
+            --collect-all numpy `
+            --collect-all sklearn `
+            --collect-all scipy `
+            pyinstaller_entry.py
+          $triple = (rustc -vV | Select-String "^host:").Line.Split(" ")[1]
+          New-Item -ItemType Directory -Force app\src-tauri\binaries | Out-Null
+          Copy-Item dist\wst.exe "app\src-tauri\binaries\wst-$triple.exe"
+
+      - name: Build Tauri app
+        shell: pwsh
+        run: cd app; npm ci; npx tauri build
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ""
+
+      - name: Locate .exe installer
+        id: exe
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem app\src-tauri\target\release\bundle\nsis\*.exe | Select-Object -First 1
+          "path=$($exe.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-cli
+          path: dist/wst.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-exe
+          path: ${{ steps.exe.outputs.path }}
+
+  linux-x86_64:
+    needs: test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
+            librsvg2-dev patchelf libssl-dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build standalone wst CLI binary
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -e . numpy scikit-learn scipy pyinstaller
+          .venv/bin/pyinstaller --onefile --name wst \
+            --collect-all wst \
+            --collect-all numpy \
+            --collect-all sklearn \
+            --collect-all scipy \
+            pyinstaller_entry.py
+          mkdir -p app/src-tauri/binaries
+          TRIPLE=$(rustc -vV | grep '^host:' | cut -d' ' -f2)
+          cp dist/wst "app/src-tauri/binaries/wst-$TRIPLE"
+          chmod +x "app/src-tauri/binaries/wst-$TRIPLE"
+
+      - name: Rename CLI for upload (platform-tagged)
+        run: cp dist/wst dist/wst-linux-x86_64
+
+      - name: Build Tauri app
+        run: cd app && npm ci && npx tauri build
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ""
+
+      - name: Locate .AppImage and .deb
+        id: linux-artifacts
+        run: |
+          IMG=$(ls app/src-tauri/target/release/bundle/appimage/*.AppImage | head -1)
+          DEB=$(ls app/src-tauri/target/release/bundle/deb/*.deb | head -1)
+          echo "appimage=$IMG" >> "$GITHUB_OUTPUT"
+          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-cli
+          path: dist/wst-linux-x86_64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-x86_64-appimage
+          path: ${{ steps.linux-artifacts.outputs.appimage }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-x86_64-deb
+          path: ${{ steps.linux-artifacts.outputs.deb }}
 
   chocolatey:
     needs: test

--- a/docs/rfcs/0007-multiplatform-releases.md
+++ b/docs/rfcs/0007-multiplatform-releases.md
@@ -1,7 +1,7 @@
 # RFC 0007: Multiplatform Releases
 
 **Issue**: #21  
-**Status**: Draft — awaiting approval  
+**Status**: Implementing  
 **Branch**: `rfc/21-soporte-multiplataforma`
 
 ---
@@ -239,11 +239,18 @@ github-release:
 
 ## Implementation Plan
 
-- [ ] Update `dmg` job to also upload standalone `wst` CLI binary
-- [ ] Add `windows-installer` job to `release.yml` (CLI + NSIS .exe)
-- [ ] Add `linux-x86_64` job to `release.yml` (CLI + .AppImage + .deb)
-- [ ] Update `github-release` job to download and attach all artifacts
-- [ ] Test on a pre-release tag (`v0.x.y-rc1`) before merging
-- [ ] Verify `.AppImage` and `.deb` work on Ubuntu 22.04 and 24.04
-- [ ] Verify `.exe` installs cleanly on Windows 11
-- [ ] Verify standalone CLI binaries run without the GUI installed
+- [x] Update `dmg` job to also upload standalone `wst` CLI binary as `wst-macos` (platform-tagged for the release page).
+- [x] Add `windows-installer` job to `release.yml` (CLI `wst.exe` + NSIS `.exe`). Mirrors macOS build flags: `numpy`/`sklearn`/`scipy` `--collect-all`.
+- [x] Add `linux-x86_64` job to `release.yml` (CLI `wst-linux-x86_64` + `.AppImage` + `.deb`). Installs `libwebkit2gtk-4.1-dev` and the other Tauri Linux deps.
+- [x] Update `github-release` job to download every artifact, flatten the directory tree (each upload-artifact creates a subdir), and attach via `softprops/action-gh-release@v2`.
+- [ ] **Smoke test on the next real release** — once a `feat:`/`fix:` lands on main and `auto-release.yml` tags `vX.Y.Z`, watch `release-on-tag.yml` and confirm all five non-Python artifacts (.dmg, .exe NSIS, .AppImage, .deb, plus the three CLI binaries) reach the GitHub release page.
+- [ ] Verify `.AppImage` and `.deb` install cleanly on Ubuntu 22.04 / 24.04.
+- [ ] Verify `.exe` installs cleanly on Windows 11.
+- [ ] Verify each standalone CLI binary runs without the GUI installed.
+
+### Implementation notes
+
+- The macOS `dmg` and Linux `linux-x86_64` jobs copy `dist/wst` to a platform-tagged filename (`wst-macos` / `wst-linux-x86_64`) before uploading so the release page shows distinct asset names. Windows uploads `dist/wst.exe` directly — Windows users expect the `.exe` extension.
+- All three Tauri builds run with `TAURI_SIGNING_PRIVATE_KEY: ""` (no code signing). macOS users still need `xattr -cr` (documented in README); Windows users will see SmartScreen warnings until we sign.
+- Chocolatey continues to push to the registry separately (kept `continue-on-error: true`); the new `windows-installer` job is the direct-download channel.
+- ARM64 Linux skipped per Q1 — no paid runners.

--- a/docs/rfcs/0007-multiplatform-releases.md
+++ b/docs/rfcs/0007-multiplatform-releases.md
@@ -1,0 +1,211 @@
+# RFC 0007: Multiplatform Releases
+
+**Issue**: #21  
+**Status**: Draft — awaiting approval  
+**Branch**: `rfc/21-soporte-multiplataforma`
+
+---
+
+## Problem
+
+Release artifacts currently cover only macOS (.dmg via the `dmg` job). The Chocolatey job publishes to the Chocolatey registry but does not attach a Windows installer to the GitHub release. Linux users have no binary artifact at all — they must install from PyPI and run the CLI only, or build Tauri locally.
+
+The goal is for every tagged release to include installable artifacts for all three platforms directly on the GitHub release page.
+
+---
+
+## Proposed Solution
+
+Add two new build jobs to `.github/workflows/release.yml` — one for Windows, one for Linux — mirroring the existing `dmg` job structure. Each job:
+
+1. Checks out the tag.
+2. Builds a standalone `wst` CLI binary via PyInstaller (must run on the target OS — no cross-compilation).
+3. Copies the binary into `app/src-tauri/binaries/` with the Rust target triple suffix.
+4. Runs `npx tauri build` to produce the platform installer.
+5. Uploads the artifact.
+
+The `github-release` job then downloads all artifacts and attaches them to the release.
+
+### New jobs
+
+#### `windows-installer` (runs-on: `windows-latest`)
+
+Tauri on Windows produces an `.msi` (WiX) and a `.exe` (NSIS) installer. We attach the `.exe`.
+
+```yaml
+windows-installer:
+  needs: test
+  runs-on: windows-latest
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.version && format('v{0}', inputs.version) || github.ref }}
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: Build standalone wst CLI binary
+      shell: pwsh
+      run: |
+        python -m venv .venv
+        .venv\Scripts\pip install -e . pyinstaller
+        .venv\Scripts\pyinstaller --onefile --name wst --collect-all wst pyinstaller_entry.py
+        $triple = rustc -vV | Select-String "^host:" | ForEach-Object { $_.Line.Split(" ")[1] }
+        New-Item -ItemType Directory -Force app\src-tauri\binaries
+        Copy-Item dist\wst.exe "app\src-tauri\binaries\wst-$triple.exe"
+
+    - name: Build Tauri app
+      run: cd app && npm ci && npx tauri build
+      shell: pwsh
+      env:
+        TAURI_SIGNING_PRIVATE_KEY: ""
+
+    - name: Locate .exe installer
+      id: exe
+      shell: pwsh
+      run: |
+        $exe = Get-ChildItem app\src-tauri\target\release\bundle\nsis\*.exe | Select-Object -First 1
+        echo "path=$($exe.FullName)" >> $env:GITHUB_OUTPUT
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: windows-exe
+        path: ${{ steps.exe.outputs.path }}
+```
+
+#### `linux-x86_64` (runs-on: `ubuntu-22.04`)
+
+Tauri on Linux produces `.deb` and `.AppImage`. We attach the `.AppImage` (runs without installation on any distro).
+
+```yaml
+linux-x86_64:
+  needs: test
+  runs-on: ubuntu-22.04
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.version && format('v{0}', inputs.version) || github.ref }}
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
+          librsvg2-dev patchelf libssl-dev
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: Build standalone wst CLI binary
+      run: |
+        python -m venv .venv
+        .venv/bin/pip install -e . pyinstaller
+        .venv/bin/pyinstaller --onefile --name wst --collect-all wst pyinstaller_entry.py
+        mkdir -p app/src-tauri/binaries
+        TRIPLE=$(rustc -vV | grep '^host:' | cut -d' ' -f2)
+        cp dist/wst "app/src-tauri/binaries/wst-$TRIPLE"
+        chmod +x "app/src-tauri/binaries/wst-$TRIPLE"
+
+    - name: Build Tauri app
+      run: cd app && npm ci && npx tauri build
+      env:
+        TAURI_SIGNING_PRIVATE_KEY: ""
+
+    - name: Locate .AppImage
+      id: appimage
+      run: |
+        IMG=$(ls app/src-tauri/target/release/bundle/appimage/*.AppImage | head -1)
+        echo "path=$IMG" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: linux-x86_64-appimage
+        path: ${{ steps.appimage.outputs.path }}
+```
+
+#### Linux ARM64
+
+GitHub-hosted runners do not offer ARM Linux. Two viable options:
+
+| Option | Tradeoff |
+|--------|----------|
+| `runs-on: ubuntu-22.04-arm` (GitHub larger runner, paid) | Simplest — same job structure as x86_64, but requires enabling larger runners on the org |
+| QEMU cross-compilation via `docker/setup-qemu-action` + Tauri cross-compile | Free, but slower (~3×) and more complex toolchain setup |
+
+**Recommendation**: start with the paid ARM runner if the repo is on a plan that includes it; fall back to QEMU otherwise. This RFC proposes the ARM runner path (`runs-on: ubuntu-22.04-arm`) and marks it `continue-on-error: true` until confirmed to work, same as the current Chocolatey job.
+
+### Updated `github-release` job
+
+The existing job generates release notes but does not attach binaries. Replace it with:
+
+```yaml
+github-release:
+  needs: [publish, windows-installer, linux-x86_64]
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        path: release-artifacts
+
+    - name: Flatten artifacts
+      run: find release-artifacts -type f | xargs -I{} mv {} release-artifacts/
+
+    - uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.ref_name }}
+        generate_release_notes: true
+        files: |
+          release-artifacts/*.dmg
+          release-artifacts/*.exe
+          release-artifacts/*.AppImage
+```
+
+The `.dmg` is already produced by the `dmg` job (uploaded as `macos-dmg`), so no changes to that job are needed.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Electron instead of Tauri | Much larger bundle size; we're already on Tauri |
+| Only ship PyPI + Chocolatey (no Tauri binaries) | Linux users get no GUI app; Windows users have no direct download |
+| Cross-compile all targets from macOS | PyInstaller cannot cross-compile; Tauri cross-compilation is experimental |
+| Ship `.deb` instead of `.AppImage` for Linux | `.AppImage` is distro-agnostic; `.deb` only targets Debian/Ubuntu natively |
+
+---
+
+## Open Questions
+
+> **Q1**: Does the repo's GitHub plan include `ubuntu-22.04-arm` larger runners? If not, should we use QEMU or simply skip ARM for now and add it later?
+
+> **Q2**: Should we also attach the `.deb` artifact for users who prefer native package manager installation on Ubuntu?
+
+> **Q3**: The Chocolatey job already runs on Windows but only pushes to the registry. Should the new `windows-installer` job replace it entirely, or should we keep both (registry push + direct .exe on the release)?
+
+---
+
+## Implementation Plan
+
+- [ ] Add `windows-installer` job to `release.yml`
+- [ ] Add `linux-x86_64` job to `release.yml`
+- [ ] Add `linux-arm64` job to `release.yml` (`continue-on-error: true`)
+- [ ] Update `github-release` job to download and attach all artifacts
+- [ ] Test on a pre-release tag (`v0.x.y-rc1`) before merging
+- [ ] Verify `.AppImage` runs on Ubuntu 22.04 and 24.04
+- [ ] Verify `.exe` installs cleanly on Windows 11

--- a/docs/rfcs/0007-multiplatform-releases.md
+++ b/docs/rfcs/0007-multiplatform-releases.md
@@ -10,27 +10,57 @@
 
 Release artifacts currently cover only macOS (.dmg via the `dmg` job). The Chocolatey job publishes to the Chocolatey registry but does not attach a Windows installer to the GitHub release. Linux users have no binary artifact at all — they must install from PyPI and run the CLI only, or build Tauri locally.
 
-The goal is for every tagged release to include installable artifacts for all three platforms directly on the GitHub release page.
+The goal is for every tagged release to include **both CLI and GUI artifacts** for all three platforms directly on the GitHub release page.
 
 ---
 
 ## Proposed Solution
 
-Add two new build jobs to `.github/workflows/release.yml` — one for Windows, one for Linux — mirroring the existing `dmg` job structure. Each job:
+Add two new build jobs to `.github/workflows/release.yml` — one for Windows, one for Linux — mirroring the existing `dmg` job structure. Each job produces **two artifacts per platform**:
 
+1. A **standalone CLI binary** (`wst` / `wst.exe`) built via PyInstaller.
+2. A **GUI installer** (Tauri app) that bundles the CLI internally.
+
+Each job:
 1. Checks out the tag.
 2. Builds a standalone `wst` CLI binary via PyInstaller (must run on the target OS — no cross-compilation).
 3. Copies the binary into `app/src-tauri/binaries/` with the Rust target triple suffix.
-4. Runs `npx tauri build` to produce the platform installer.
-5. Uploads the artifact.
+4. Runs `npx tauri build` to produce the platform GUI installer.
+5. Uploads both artifacts.
 
 The `github-release` job then downloads all artifacts and attaches them to the release.
 
-### New jobs
+### Artifact matrix
 
-#### `windows-installer` (runs-on: `windows-latest`)
+| Platform | CLI artifact | GUI artifact |
+|----------|-------------|-------------|
+| macOS    | `wst-macos` (standalone binary) | `wst_<ver>_universal.dmg` |
+| Windows  | `wst.exe` (standalone binary) | `wst_<ver>_x64-setup.exe` (NSIS) |
+| Linux x86_64 | `wst-linux-x86_64` (standalone binary) | `wst_<ver>_amd64.AppImage` + `wst_<ver>_amd64.deb` |
 
-Tauri on Windows produces an `.msi` (WiX) and a `.exe` (NSIS) installer. We attach the `.exe`.
+ARM64 Linux is skipped for now — no paid GitHub runners available, and QEMU cross-compilation is too fragile. Can be added later.
+
+### Updated `dmg` job (macOS)
+
+Add a step to upload the standalone CLI binary alongside the existing DMG:
+
+```yaml
+- name: Upload standalone CLI
+  uses: actions/upload-artifact@v4
+  with:
+    name: macos-cli
+    path: dist/wst
+
+- name: Upload DMG
+  uses: actions/upload-artifact@v4
+  with:
+    name: macos-dmg
+    path: ${{ steps.dmg.outputs.path }}
+```
+
+### New `windows-installer` job (runs-on: `windows-latest`)
+
+Tauri on Windows produces an `.msi` (WiX) and a `.exe` (NSIS) installer. We attach the `.exe`. The existing Chocolatey job is kept as-is — it remains a separate channel.
 
 ```yaml
 windows-installer:
@@ -76,13 +106,18 @@ windows-installer:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: windows-cli
+        path: dist/wst.exe
+
+    - uses: actions/upload-artifact@v4
+      with:
         name: windows-exe
         path: ${{ steps.exe.outputs.path }}
 ```
 
-#### `linux-x86_64` (runs-on: `ubuntu-22.04`)
+### New `linux-x86_64` job (runs-on: `ubuntu-22.04`)
 
-Tauri on Linux produces `.deb` and `.AppImage`. We attach the `.AppImage` (runs without installation on any distro).
+Tauri on Linux produces `.deb` and `.AppImage`. We attach **both** — `.AppImage` for distro-agnostic use, `.deb` for native Ubuntu/Debian package management.
 
 ```yaml
 linux-x86_64:
@@ -124,36 +159,35 @@ linux-x86_64:
       env:
         TAURI_SIGNING_PRIVATE_KEY: ""
 
-    - name: Locate .AppImage
-      id: appimage
+    - name: Locate .AppImage and .deb
+      id: linux-artifacts
       run: |
         IMG=$(ls app/src-tauri/target/release/bundle/appimage/*.AppImage | head -1)
-        echo "path=$IMG" >> "$GITHUB_OUTPUT"
+        DEB=$(ls app/src-tauri/target/release/bundle/deb/*.deb | head -1)
+        echo "appimage=$IMG" >> "$GITHUB_OUTPUT"
+        echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: linux-cli
+        path: dist/wst
 
     - uses: actions/upload-artifact@v4
       with:
         name: linux-x86_64-appimage
-        path: ${{ steps.appimage.outputs.path }}
+        path: ${{ steps.linux-artifacts.outputs.appimage }}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: linux-x86_64-deb
+        path: ${{ steps.linux-artifacts.outputs.deb }}
 ```
-
-#### Linux ARM64
-
-GitHub-hosted runners do not offer ARM Linux. Two viable options:
-
-| Option | Tradeoff |
-|--------|----------|
-| `runs-on: ubuntu-22.04-arm` (GitHub larger runner, paid) | Simplest — same job structure as x86_64, but requires enabling larger runners on the org |
-| QEMU cross-compilation via `docker/setup-qemu-action` + Tauri cross-compile | Free, but slower (~3×) and more complex toolchain setup |
-
-**Recommendation**: start with the paid ARM runner if the repo is on a plan that includes it; fall back to QEMU otherwise. This RFC proposes the ARM runner path (`runs-on: ubuntu-22.04-arm`) and marks it `continue-on-error: true` until confirmed to work, same as the current Chocolatey job.
 
 ### Updated `github-release` job
 
-The existing job generates release notes but does not attach binaries. Replace it with:
-
 ```yaml
 github-release:
-  needs: [publish, windows-installer, linux-x86_64]
+  needs: [publish, dmg, windows-installer, linux-x86_64]
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@v4
@@ -173,9 +207,22 @@ github-release:
           release-artifacts/*.dmg
           release-artifacts/*.exe
           release-artifacts/*.AppImage
+          release-artifacts/*.deb
+          release-artifacts/wst
+          release-artifacts/wst.exe
+          release-artifacts/wst-macos
 ```
 
-The `.dmg` is already produced by the `dmg` job (uploaded as `macos-dmg`), so no changes to that job are needed.
+---
+
+## Decisions from review
+
+| Question | Decision |
+|----------|----------|
+| ARM64 Linux | Skip for now — no paid runners available |
+| Linux artifacts | Ship both `.AppImage` and `.deb` |
+| Windows Chocolatey vs direct download | Keep both — Chocolatey job unchanged, `windows-installer` adds direct `.exe` to the release |
+| Per-platform artifacts | Each platform ships **both** a standalone CLI binary and the GUI installer |
 
 ---
 
@@ -186,26 +233,17 @@ The `.dmg` is already produced by the `dmg` job (uploaded as `macos-dmg`), so no
 | Electron instead of Tauri | Much larger bundle size; we're already on Tauri |
 | Only ship PyPI + Chocolatey (no Tauri binaries) | Linux users get no GUI app; Windows users have no direct download |
 | Cross-compile all targets from macOS | PyInstaller cannot cross-compile; Tauri cross-compilation is experimental |
-| Ship `.deb` instead of `.AppImage` for Linux | `.AppImage` is distro-agnostic; `.deb` only targets Debian/Ubuntu natively |
-
----
-
-## Open Questions
-
-> **Q1**: Does the repo's GitHub plan include `ubuntu-22.04-arm` larger runners? If not, should we use QEMU or simply skip ARM for now and add it later?
-
-> **Q2**: Should we also attach the `.deb` artifact for users who prefer native package manager installation on Ubuntu?
-
-> **Q3**: The Chocolatey job already runs on Windows but only pushes to the registry. Should the new `windows-installer` job replace it entirely, or should we keep both (registry push + direct .exe on the release)?
+| Ship only `.AppImage` for Linux | `.deb` requested for users who prefer native package management |
 
 ---
 
 ## Implementation Plan
 
-- [ ] Add `windows-installer` job to `release.yml`
-- [ ] Add `linux-x86_64` job to `release.yml`
-- [ ] Add `linux-arm64` job to `release.yml` (`continue-on-error: true`)
+- [ ] Update `dmg` job to also upload standalone `wst` CLI binary
+- [ ] Add `windows-installer` job to `release.yml` (CLI + NSIS .exe)
+- [ ] Add `linux-x86_64` job to `release.yml` (CLI + .AppImage + .deb)
 - [ ] Update `github-release` job to download and attach all artifacts
 - [ ] Test on a pre-release tag (`v0.x.y-rc1`) before merging
-- [ ] Verify `.AppImage` runs on Ubuntu 22.04 and 24.04
+- [ ] Verify `.AppImage` and `.deb` work on Ubuntu 22.04 and 24.04
 - [ ] Verify `.exe` installs cleanly on Windows 11
+- [ ] Verify standalone CLI binaries run without the GUI installed


### PR DESCRIPTION
Closes #21

This PR contains RFC 0007 proposing multiplatform release artifacts for the Tauri app.

**The problem**: GitHub releases only contain a macOS `.dmg`. Windows users have no direct download (only Chocolatey registry), and Linux users have no binary at all.

**The proposal**: Add `windows-installer` and `linux-x86_64` jobs to the release workflow, each building the PyInstaller CLI binary and then the Tauri installer on the target OS, and update `github-release` to attach all artifacts.

## What's in this PR (RFC phase)

- `docs/rfcs/0007-multiplatform-releases.md` — full design with CI job YAML, artifact strategy, and ARM discussion

## Before I implement

Please review the RFC and leave a comment here (or on issue #21) with one of:
- ✅ **approved** — I'll add the implementation to this PR
- 🔁 **changes: \<what to change\>** — I'll revise the RFC accordingly

Open questions (Q1–Q3) are listed in the RFC, especially around ARM runner availability.