### PR TITLE
RFC: Instalación de paquetes extra via CLI y GUI

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -20,10 +20,11 @@ import {
 } from "./lib/tauri";
 import SearchBar from "./components/SearchBar";
 import Sidebar from "./components/Sidebar";
-import Toolbar from "./components/Toolbar";
+import Toolbar, { showExtras, setShowExtras } from "./components/Toolbar";
 import BookGrid from "./components/BookGrid";
 import BookList from "./components/BookList";
 import BookDetail from "./components/BookDetail";
+import ExtrasPanel from "./components/ExtrasPanel";
 
 export default function App() {
   let debounceTimer: number | undefined;
@@ -106,6 +107,9 @@ export default function App() {
         </main>
       </div>
       <BookDetail />
+      <Show when={showExtras()}>
+        <ExtrasPanel onClose={() => setShowExtras(false)} />
+      </Show>
     </div>
   );
 }

--- a/app/src/components/ExtrasPanel.tsx
+++ b/app/src/components/ExtrasPanel.tsx
@@ -1,0 +1,118 @@
+import { createSignal, For, onMount, Show } from "solid-js";
+import { getExtrasStatus, installExtra } from "../lib/tauri";
+import type { ExtraInfo } from "../lib/tauri";
+
+const EXTRA_LABELS: Record<string, { name: string; icon: string }> = {
+  ocr: { name: "OCR", icon: "🔍" },
+  topics: { name: "Topic Modeling", icon: "🏷️" },
+};
+
+type InstallState = "idle" | "installing" | "done" | "error";
+
+interface ExtraEntry {
+  key: string;
+  info: ExtraInfo;
+}
+
+export default function ExtrasPanel(props: { onClose: () => void }) {
+  const [extras, setExtras] = createSignal<ExtraEntry[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [installState, setInstallState] = createSignal<Record<string, InstallState>>({});
+  const [installLog, setInstallLog] = createSignal<Record<string, string>>({});
+
+  onMount(async () => {
+    await refresh();
+  });
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const status = await getExtrasStatus();
+      setExtras(Object.entries(status).map(([key, info]) => ({ key, info })));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleInstall(key: string, upgrade = false) {
+    setInstallState((s) => ({ ...s, [key]: "installing" }));
+    setInstallLog((l) => ({ ...l, [key]: "" }));
+    try {
+      const out = await installExtra(key, upgrade);
+      setInstallLog((l) => ({ ...l, [key]: out || "Instalado correctamente." }));
+      setInstallState((s) => ({ ...s, [key]: "done" }));
+      await refresh();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setInstallLog((l) => ({ ...l, [key]: msg }));
+      setInstallState((s) => ({ ...s, [key]: "error" }));
+    }
+  }
+
+  return (
+    <div class="detail-overlay" onClick={(e) => e.target === e.currentTarget && props.onClose()}>
+      <div class="detail-panel extras-panel">
+        <button class="detail-close" onClick={props.onClose} title="Cerrar">×</button>
+
+        <h2 class="extras-title">Extras instalables</h2>
+        <p class="extras-subtitle">
+          Funciones opcionales que requieren paquetes adicionales.
+        </p>
+
+        <Show when={loading()}>
+          <p class="extras-loading">Cargando estado...</p>
+        </Show>
+
+        <Show when={!loading()}>
+          <For each={extras()}>
+            {({ key, info }) => {
+              const label = EXTRA_LABELS[key] ?? { name: key, icon: "📦" };
+              const state = () => installState()[key] ?? "idle";
+              const log = () => installLog()[key] ?? "";
+
+              return (
+                <div class={`extras-card ${info.installed ? "installed" : ""}`}>
+                  <div class="extras-card-header">
+                    <span class="extras-icon">{label.icon}</span>
+                    <div class="extras-card-info">
+                      <span class="extras-name">{label.name}</span>
+                      <span class="extras-desc">{info.description}</span>
+                    </div>
+                    <div class="extras-status-area">
+                      <Show when={info.installed}>
+                        <span class="extras-badge installed">✓ Instalado</span>
+                        <button
+                          class="extras-btn upgrade"
+                          disabled={state() === "installing"}
+                          onClick={() => handleInstall(key, true)}
+                        >
+                          {state() === "installing" ? "Actualizando…" : "Actualizar"}
+                        </button>
+                      </Show>
+                      <Show when={!info.installed}>
+                        <span class="extras-badge missing">✗ No instalado</span>
+                        <button
+                          class="extras-btn install"
+                          disabled={state() === "installing"}
+                          onClick={() => handleInstall(key)}
+                        >
+                          {state() === "installing" ? "Instalando…" : "Instalar"}
+                        </button>
+                      </Show>
+                    </div>
+                  </div>
+
+                  <Show when={log()}>
+                    <pre
+                      class={`extras-log ${state() === "error" ? "error" : state() === "done" ? "done" : ""}`}
+                    >{log()}</pre>
+                  </Show>
+                </div>
+              );
+            }}
+          </For>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/Toolbar.tsx
+++ b/app/src/components/Toolbar.tsx
@@ -1,6 +1,8 @@
 import { createSignal } from "solid-js";
 import { viewMode, setViewMode, sortBy, setSortBy, documents } from "../lib/store";
 
+export const [showExtras, setShowExtras] = createSignal(false);
+
 export default function Toolbar() {
   return (
     <div class="toolbar">
@@ -17,6 +19,16 @@ export default function Toolbar() {
           <option value="year">Año</option>
           <option value="ingested_at">Recién añadidos</option>
         </select>
+
+        <button
+          class="view-btn"
+          onClick={() => setShowExtras(true)}
+          title="Extras instalables"
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+            <path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 01-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 01.872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 012.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 012.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 01.872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 01-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 01-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 110-5.858 2.929 2.929 0 010 5.858z"/>
+          </svg>
+        </button>
 
         <div class="view-toggle">
           <button

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -79,3 +79,24 @@ export async function backupDocumentToIcloud(id: number): Promise<void> {
     args: ["backup", "icloud", String(id), "--format", "json"],
   });
 }
+
+export interface ExtraInfo {
+  installed: boolean;
+  description: string;
+  package: string;
+  check_modules: string[];
+  system_deps: string[];
+}
+
+export async function getExtrasStatus(): Promise<Record<string, ExtraInfo>> {
+  const raw = await invoke<string>("run_wst_command", {
+    args: ["install", "--list", "--json"],
+  });
+  return JSON.parse(raw);
+}
+
+export async function installExtra(name: string, upgrade = false): Promise<string> {
+  const args = ["install", name];
+  if (upgrade) args.push("--upgrade");
+  return invoke<string>("run_wst_command", { args });
+}

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -803,3 +803,159 @@ body.resizing {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-faint);
 }
+
+/* Extras panel */
+.extras-panel {
+  width: 480px;
+}
+
+.extras-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.extras-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+
+.extras-loading {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.extras-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  background: var(--bg-card);
+}
+
+.extras-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.extras-icon {
+  font-size: 22px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.extras-card-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.extras-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.extras-desc {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.extras-status-area {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.extras-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 20px;
+}
+
+.extras-badge.installed {
+  background: #d4edda;
+  color: #155724;
+}
+
+@media (prefers-color-scheme: dark) {
+  .extras-badge.installed {
+    background: #1e3a2a;
+    color: #6fcf97;
+  }
+}
+
+.extras-badge.missing {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+@media (prefers-color-scheme: dark) {
+  .extras-badge.missing {
+    background: #3a1e20;
+    color: #eb5757;
+  }
+}
+
+.extras-btn {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.extras-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.extras-btn.install {
+  background: var(--accent);
+  color: #fff;
+}
+
+.extras-btn.install:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.extras-btn.upgrade {
+  background: var(--bg-hover);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.extras-btn.upgrade:hover:not(:disabled) {
+  background: var(--border);
+}
+
+.extras-log {
+  margin-top: 10px;
+  font-size: 11px;
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg-hover);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  max-height: 160px;
+  overflow-y: auto;
+  color: var(--text-muted);
+}
+
+.extras-log.done {
+  border-left: 3px solid #28a745;
+}
+
+.extras-log.error {
+  border-left: 3px solid #dc3545;
+  color: #dc3545;
+}

--- a/docs/rfcs/0008-install-extras-command.md
+++ b/docs/rfcs/0008-install-extras-command.md
@@ -1,7 +1,7 @@
 # RFC 0008: Install Extras via CLI and GUI
 
 **Issue**: #22  
-**Status**: Draft — awaiting approval  
+**Status**: Implementing  
 **Branch**: `rfc/22-instalacion-paquetes-extra`
 
 ---
@@ -23,12 +23,13 @@ This friction is especially high for non-technical users using the Tauri app. Th
 
 ### 1 — `wst install <extra>` CLI command
 
-Add a new top-level command that installs an optional extras group into the current Python environment:
+Add a new top-level command that installs an optional extras group:
 
 ```
-wst install ocr       # installs wst-library[ocr]
+wst install ocr       # installs wst-library[ocr] + system deps (Ghostscript, Tesseract)
 wst install topics    # installs wst-library[topics]
 wst install --list    # shows all extras and their install status
+wst install ocr --upgrade   # force upgrade of already-installed extra
 ```
 
 Implementation in `src/wst/cli.py`:
@@ -42,19 +43,12 @@ EXTRAS = {
 @cli.command()
 @click.argument("extra", required=False)
 @click.option("--list", "list_extras", is_flag=True)
-def install(extra: str | None, list_extras: bool) -> None:
+@click.option("--upgrade", is_flag=True)
+def install(extra: str | None, list_extras: bool, upgrade: bool) -> None:
     """Install optional feature packages."""
 ```
 
-The command resolves the Python executable via `sys.executable` and runs:
-
-```python
-subprocess.run([sys.executable, "-m", "pip", "install", package_spec], check=True)
-```
-
-This ensures the packages land in the same environment as `wst` itself.
-
-**Status detection**: before installing, check importability of the key modules to show what's already installed:
+**Status detection**: check importability of key modules before installing:
 
 ```
 $ wst install --list
@@ -62,31 +56,54 @@ ocr       ✗ not installed   → wst install ocr
 topics    ✓ installed
 ```
 
-### 2 — Tauri app: Settings / Extras page
+**Auto-upgrade**: if `--upgrade` is passed (or will be triggered automatically by `wst` on startup when a newer version is detected), re-run the install with `--upgrade` on the pip call.
 
-Add a new **Settings** sidebar item (or a dedicated **Extras** section in an existing settings panel) that:
+### 2 — System dependencies for OCR
 
-1. On mount, calls `wst install --list --json` (a machine-readable variant) to fetch install status.
-2. Renders a card per extra with name, description, and an **Install** button for uninstalled ones.
-3. On button click, invokes `wst install <extra>` via Tauri's `Command` API and streams stdout to a log panel.
+`ocrmypdf` requires Ghostscript and Tesseract, which are not Python packages. `wst install ocr` will:
+
+1. **Check** if Ghostscript and Tesseract are available (`shutil.which("gs")`, `shutil.which("tesseract")`).
+2. If missing, **download and install** them using the platform-appropriate method:
+
+| Platform | Ghostscript | Tesseract |
+|----------|-------------|-----------|
+| macOS | Download `.pkg` from ghostscript.com + run installer, or `brew install ghostscript` if Homebrew is present | `brew install tesseract` or download `.pkg` |
+| Windows | Download NSIS `.exe` from ghostscript.com + silent install (`/S`), UB Mannheim Tesseract `.exe` + silent install | Same |
+| Linux | `sudo apt-get install ghostscript tesseract-ocr` | Same |
+
+The download-and-run approach (no Homebrew/apt required) is the baseline; package managers are used when detected.
+
+### 3 — Bundled (PyInstaller) case: side-car venv with embedded Python
+
+When `wst` is packaged as a PyInstaller one-file binary, `sys.executable` points to the frozen binary — `pip` is unavailable. Rather than requiring system Python, we bundle a Python interpreter alongside the app using **python-build-standalone**.
+
+**Flow**:
+
+1. The Tauri app ships a platform-specific `python-embed/` directory alongside the bundled `wst` binary, containing a standalone Python interpreter (from [python-build-standalone](https://github.com/indygreg/python-build-standalone) releases, ~30 MB compressed).
+2. On first `wst install`, if running frozen, the command detects `sys.frozen` and uses `python-embed/python` (or `python-embed/python.exe`) instead of `sys.executable`.
+3. A side-car venv is created at `~/.wst/extras/` using that embedded interpreter: `python-embed/python -m venv ~/.wst/extras/`.
+4. The extras are installed into the venv, and `~/.wst/extras/lib/pythonX.Y/site-packages` is added to `sys.path` at `wst` startup.
+
+The CI release workflow downloads the appropriate python-build-standalone artifact for each platform and places it in `app/src-tauri/resources/python-embed/` during the build.
+
+### 4 — Tauri app: Settings / Extras page
+
+Add a **Settings → Extras** section that:
+
+1. On mount, calls `wst install --list --json` to fetch install status.
+2. Renders a card per extra with name, description, install/upgrade button.
+3. On button click, invokes `wst install <extra>` via Tauri's `Command` API and streams stdout/stderr to a log panel.
 4. Shows a spinner while running, then ✓/✗ based on exit code.
 
-No new Tauri Rust code is needed — the Tauri app already shells out to the bundled `wst` binary for all operations.
+---
 
-### Bundled (PyInstaller) case
+## Decisions from review
 
-When `wst` is packaged as a PyInstaller one-file binary, `sys.executable` points to the frozen binary itself, not a Python interpreter — `pip` is not available.
-
-Two options for this case:
-
-| Option | Approach |
-|--------|----------|
-| **A — ship all extras in the bundle** | Add `ocr` and `topics` deps to the PyInstaller spec. Larger bundle (~400 MB → ~700 MB) but zero install friction |
-| **B — side-car venv** | On first `wst install`, create a side-car venv at `~/.wst/extras/` using the system Python, install there, and add it to `sys.path` at startup |
-
-Option A is simpler and eliminates the install flow entirely for Tauri app users. Option B keeps the bundle lean but requires a system Python.
-
-> See **Q1** below for input on which to pursue.
+| Question | Decision |
+|----------|----------|
+| Bundled case | Side-car venv at `~/.wst/extras/` using embedded Python (python-build-standalone) |
+| Upgrades | `--upgrade` flag supported; auto-upgrade path TBD in a follow-up |
+| System deps (OCR) | `wst install ocr` handles Ghostscript + Tesseract — downloads and runs installers, uses package managers when detected |
 
 ---
 
@@ -94,28 +111,22 @@ Option A is simpler and eliminates the install flow entirely for Tauri app users
 
 | Alternative | Why rejected |
 |-------------|-------------|
-| Document-only (better README) | Doesn't help Tauri app users who never see the README |
-| Auto-install on first use (transparent) | Installs without consent; surprising and potentially slow mid-command |
-| Separate installers per platform | Duplicates distribution work; extras are pip packages, not system packages |
-
----
-
-## Open Questions
-
-> **Q1**: For the Tauri/bundled case, do you prefer Option A (bundle all extras — simpler UX, larger download) or Option B (side-car venv — lean bundle, needs system Python)?
-
-> **Q2**: Should `wst install` support upgrading already-installed extras (`--upgrade` flag), or just initial install?
-
-> **Q3**: `ocrmypdf` has a system-level dependency (Ghostscript, Tesseract). Should `wst install ocr` also check for and guide the user through system dependency installation, or scope this to Python packages only?
+| Bundle all extras in PyInstaller | Bundle grows ~300 MB; user pays the cost even if they never use OCR/topics |
+| Require system Python for side-car | On Windows, Python is not installed by default; embedded Python removes this dependency |
+| Scope to Python packages only (no system deps) | OCR is unusable without Ghostscript/Tesseract; completing the install in one step is better UX |
+| Auto-install on first use (transparent) | Installs without consent and is potentially slow mid-command |
 
 ---
 
 ## Implementation Plan
 
 - [ ] Add `wst install <extra>` command to `src/wst/cli.py`
-- [ ] Add `--list` / `--list --json` output for status detection
-- [ ] Write tests for install status detection (mock importlib)
-- [ ] Add **Extras** section to the Tauri app settings UI
-- [ ] Wire up `wst install <extra>` via Tauri `Command` API with streaming output
-- [ ] Decide and implement bundled-case strategy (Q1)
-- [ ] Update help text / docs for `wst ocr` and `wst topics` to reference `wst install`
+- [ ] Add `--list` / `--list --json` and `--upgrade` flags
+- [ ] Implement system dependency installer (Ghostscript + Tesseract) with platform detection
+- [ ] Detect `sys.frozen` and route to embedded Python / side-car venv
+- [ ] Download python-build-standalone in CI and bundle in `app/src-tauri/resources/`
+- [ ] Add side-car venv creation + `sys.path` injection at `wst` startup
+- [ ] Write tests for install status detection and frozen-mode path
+- [ ] Add **Settings → Extras** section to Tauri app
+- [ ] Wire up streaming `wst install` output in the GUI
+- [ ] Update help text for `wst ocr` and `wst topics` to reference `wst install`

--- a/docs/rfcs/0008-install-extras-command.md
+++ b/docs/rfcs/0008-install-extras-command.md
@@ -1,0 +1,121 @@
+# RFC 0008: Install Extras via CLI and GUI
+
+**Issue**: #22  
+**Status**: Draft — awaiting approval  
+**Branch**: `rfc/22-instalacion-paquetes-extra`
+
+---
+
+## Problem
+
+Optional features (OCR via `ocrmypdf`, topic modeling via `sentence-transformers` + `scikit-learn`) require users to manually run:
+
+```
+pip install "wst-library[ocr]"
+pip install "wst-library[topics]"
+```
+
+This friction is especially high for non-technical users using the Tauri app. There is no in-app discovery of what's missing or how to install it. Features silently fail or show cryptic errors when the extras aren't installed.
+
+---
+
+## Proposed Solution
+
+### 1 — `wst install <extra>` CLI command
+
+Add a new top-level command that installs an optional extras group into the current Python environment:
+
+```
+wst install ocr       # installs wst-library[ocr]
+wst install topics    # installs wst-library[topics]
+wst install --list    # shows all extras and their install status
+```
+
+Implementation in `src/wst/cli.py`:
+
+```python
+EXTRAS = {
+    "ocr": ("wst-library[ocr]", ["ocrmypdf"]),
+    "topics": ("wst-library[topics]", ["sentence_transformers", "sklearn"]),
+}
+
+@cli.command()
+@click.argument("extra", required=False)
+@click.option("--list", "list_extras", is_flag=True)
+def install(extra: str | None, list_extras: bool) -> None:
+    """Install optional feature packages."""
+```
+
+The command resolves the Python executable via `sys.executable` and runs:
+
+```python
+subprocess.run([sys.executable, "-m", "pip", "install", package_spec], check=True)
+```
+
+This ensures the packages land in the same environment as `wst` itself.
+
+**Status detection**: before installing, check importability of the key modules to show what's already installed:
+
+```
+$ wst install --list
+ocr       ✗ not installed   → wst install ocr
+topics    ✓ installed
+```
+
+### 2 — Tauri app: Settings / Extras page
+
+Add a new **Settings** sidebar item (or a dedicated **Extras** section in an existing settings panel) that:
+
+1. On mount, calls `wst install --list --json` (a machine-readable variant) to fetch install status.
+2. Renders a card per extra with name, description, and an **Install** button for uninstalled ones.
+3. On button click, invokes `wst install <extra>` via Tauri's `Command` API and streams stdout to a log panel.
+4. Shows a spinner while running, then ✓/✗ based on exit code.
+
+No new Tauri Rust code is needed — the Tauri app already shells out to the bundled `wst` binary for all operations.
+
+### Bundled (PyInstaller) case
+
+When `wst` is packaged as a PyInstaller one-file binary, `sys.executable` points to the frozen binary itself, not a Python interpreter — `pip` is not available.
+
+Two options for this case:
+
+| Option | Approach |
+|--------|----------|
+| **A — ship all extras in the bundle** | Add `ocr` and `topics` deps to the PyInstaller spec. Larger bundle (~400 MB → ~700 MB) but zero install friction |
+| **B — side-car venv** | On first `wst install`, create a side-car venv at `~/.wst/extras/` using the system Python, install there, and add it to `sys.path` at startup |
+
+Option A is simpler and eliminates the install flow entirely for Tauri app users. Option B keeps the bundle lean but requires a system Python.
+
+> See **Q1** below for input on which to pursue.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Document-only (better README) | Doesn't help Tauri app users who never see the README |
+| Auto-install on first use (transparent) | Installs without consent; surprising and potentially slow mid-command |
+| Separate installers per platform | Duplicates distribution work; extras are pip packages, not system packages |
+
+---
+
+## Open Questions
+
+> **Q1**: For the Tauri/bundled case, do you prefer Option A (bundle all extras — simpler UX, larger download) or Option B (side-car venv — lean bundle, needs system Python)?
+
+> **Q2**: Should `wst install` support upgrading already-installed extras (`--upgrade` flag), or just initial install?
+
+> **Q3**: `ocrmypdf` has a system-level dependency (Ghostscript, Tesseract). Should `wst install ocr` also check for and guide the user through system dependency installation, or scope this to Python packages only?
+
+---
+
+## Implementation Plan
+
+- [ ] Add `wst install <extra>` command to `src/wst/cli.py`
+- [ ] Add `--list` / `--list --json` output for status detection
+- [ ] Write tests for install status detection (mock importlib)
+- [ ] Add **Extras** section to the Tauri app settings UI
+- [ ] Wire up `wst install <extra>` via Tauri `Command` API with streaming output
+- [ ] Decide and implement bundled-case strategy (Q1)
+- [ ] Update help text / docs for `wst ocr` and `wst topics` to reference `wst install`

--- a/src/wst/__init__.py
+++ b/src/wst/__init__.py
@@ -1,1 +1,5 @@
 """wst — CLI tool for organizing books and PDFs."""
+
+from wst.install import inject_sidecar_path
+
+inject_sidecar_path()

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -2245,3 +2245,36 @@ def _fix_topics_cmd(
     from wst.output import render_ok
 
     render_ok({"scanned": len(entries), "updated": updated}, fmt=fmt)
+
+
+@cli.command("install")
+@click.argument("extra", required=False)
+@click.option("--list", "list_extras", is_flag=True, help="Show install status for all extras.")
+@click.option("--json", "as_json", is_flag=True, help="Machine-readable JSON output (with --list).")
+@click.option("--upgrade", is_flag=True, help="Upgrade an already-installed extra.")
+def install_cmd(extra: str | None, list_extras: bool, as_json: bool, upgrade: bool) -> None:
+    """Install optional feature packages (ocr, topics).
+
+    \b
+    Examples:
+      wst install ocr           # install OCR support + system deps
+      wst install topics        # install topic modeling support
+      wst install ocr --upgrade # upgrade OCR packages
+      wst install --list        # show what's installed
+    """
+    from wst.install import install_extra
+    from wst.install import list_extras as _list_extras
+
+    if list_extras or (extra is None and not upgrade):
+        _list_extras(as_json=as_json)
+        return
+
+    if extra is None:
+        raise click.UsageError("Specify an extra to install, or use --list.")
+
+    try:
+        install_extra(extra, upgrade=upgrade)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint="extra") from e
+    except Exception as e:
+        raise click.ClickException(str(e)) from e

--- a/src/wst/install.py
+++ b/src/wst/install.py
@@ -1,0 +1,224 @@
+"""Install optional wst extras (OCR, topics) including system dependencies."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+EXTRAS: dict[str, dict] = {
+    "ocr": {
+        "package": "wst-library[ocr]",
+        "check_modules": ["ocrmypdf"],
+        "description": "OCR support for scanned PDFs (ocrmypdf)",
+        "system_deps": ["tesseract", "ghostscript"],
+    },
+    "topics": {
+        "package": "wst-library[topics]",
+        "check_modules": ["sentence_transformers", "sklearn"],
+        "description": "Topic modeling for document clustering",
+        "system_deps": [],
+    },
+}
+
+_SYSTEM_DEP_BREW = {
+    "tesseract": ["tesseract", "tesseract-lang"],
+    "ghostscript": ["ghostscript"],
+}
+
+_SYSTEM_DEP_APT = {
+    "tesseract": ["tesseract-ocr"],
+    "ghostscript": ["ghostscript"],
+}
+
+_SYSTEM_DEP_DNF = {
+    "tesseract": ["tesseract"],
+    "ghostscript": ["ghostscript"],
+}
+
+_SYSTEM_DEP_WHICH = {
+    "tesseract": ["tesseract"],
+    "ghostscript": ["gs", "gswin64c", "gswin32c"],
+}
+
+
+def _is_frozen() -> bool:
+    return getattr(sys, "frozen", False)
+
+
+def _sidecar_venv() -> Path:
+    return Path.home() / ".wst" / "extras"
+
+
+def _find_python() -> str:
+    """Return path to a usable Python interpreter."""
+    if _is_frozen():
+        # Look for embedded Python bundled alongside the app
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            candidates = [
+                Path(meipass) / "python-embed" / "python",
+                Path(meipass) / "python-embed" / "python.exe",
+                Path(meipass).parent / "python-embed" / "python",
+                Path(meipass).parent / "python-embed" / "python.exe",
+            ]
+            for c in candidates:
+                if c.exists():
+                    return str(c)
+        raise RuntimeError(
+            "No embedded Python found. Please reinstall wst or install extras manually."
+        )
+    return sys.executable
+
+
+def _pip_target() -> list[str]:
+    """Return pip install target args for the appropriate environment."""
+    if _is_frozen():
+        venv = _sidecar_venv()
+        venv.mkdir(parents=True, exist_ok=True)
+        python = _find_python()
+        # Create venv if it doesn't exist yet
+        if not (venv / "pyvenv.cfg").exists():
+            subprocess.run([python, "-m", "venv", str(venv)], check=True)
+        # Use venv's pip
+        pip = venv / ("Scripts" if platform.system() == "Windows" else "bin") / "pip"
+        return [str(pip)]
+    return [sys.executable, "-m", "pip"]
+
+
+def inject_sidecar_path() -> None:
+    """Add the side-car extras venv to sys.path at startup (frozen mode only)."""
+    if not _is_frozen():
+        return
+    venv = _sidecar_venv()
+    if not venv.exists():
+        return
+    py_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    candidates = [
+        venv / "lib" / py_version / "site-packages",
+        venv / "Lib" / "site-packages",
+    ]
+    for site in candidates:
+        if site.exists() and str(site) not in sys.path:
+            sys.path.insert(0, str(site))
+
+
+def is_module_available(module: str) -> bool:
+    return importlib.util.find_spec(module) is not None
+
+
+def extra_status() -> dict[str, bool]:
+    """Return {extra_name: is_installed} for all known extras."""
+    return {
+        name: all(is_module_available(m) for m in info["check_modules"])
+        for name, info in EXTRAS.items()
+    }
+
+
+def _check_sys_dep(dep: str) -> bool:
+    return any(shutil.which(cmd) for cmd in _SYSTEM_DEP_WHICH[dep])
+
+
+def _install_sys_dep_macos(dep: str) -> bool:
+    """Returns True if installed successfully."""
+    if shutil.which("brew"):
+        pkgs = _SYSTEM_DEP_BREW[dep]
+        result = subprocess.run(["brew", "install", *pkgs])
+        return result.returncode == 0
+    return False
+
+
+def _install_sys_dep_linux(dep: str) -> bool:
+    if shutil.which("apt-get"):
+        pkgs = _SYSTEM_DEP_APT[dep]
+        result = subprocess.run(["sudo", "apt-get", "install", "-y", *pkgs])
+        return result.returncode == 0
+    if shutil.which("dnf"):
+        pkgs = _SYSTEM_DEP_DNF[dep]
+        result = subprocess.run(["sudo", "dnf", "install", "-y", *pkgs])
+        return result.returncode == 0
+    return False
+
+
+_MANUAL_INSTRUCTIONS: dict[str, dict[str, str]] = {
+    "tesseract": {
+        "Darwin": "  brew install tesseract tesseract-lang",
+        "Linux": "  sudo apt-get install tesseract-ocr   # or: sudo dnf install tesseract",
+        "Windows": "  Download from https://github.com/UB-Mannheim/tesseract/wiki",
+    },
+    "ghostscript": {
+        "Darwin": "  brew install ghostscript",
+        "Linux": "  sudo apt-get install ghostscript   # or: sudo dnf install ghostscript",
+        "Windows": "  Download from https://www.ghostscript.com/releases/gsdnld.html",
+    },
+}
+
+
+def install_system_dep(dep: str) -> tuple[bool, str]:
+    """Try to install a system dependency. Returns (success, message)."""
+    if _check_sys_dep(dep):
+        return True, f"{dep} already installed"
+
+    system = platform.system()
+    success = False
+    if system == "Darwin":
+        success = _install_sys_dep_macos(dep)
+    elif system == "Linux":
+        success = _install_sys_dep_linux(dep)
+
+    if success:
+        return True, f"{dep} installed"
+
+    instructions = _MANUAL_INSTRUCTIONS.get(dep, {}).get(system, f"Install {dep} manually.")
+    return False, f"{dep} not found. Install it manually:\n{instructions}"
+
+
+def install_extra(name: str, *, upgrade: bool = False) -> None:
+    """Install a named extra. Raises on failure."""
+    if name not in EXTRAS:
+        raise ValueError(f"Unknown extra: {name!r}. Valid choices: {list(EXTRAS)}")
+
+    info = EXTRAS[name]
+
+    # Install system deps first
+    for dep in info["system_deps"]:
+        ok, msg = install_system_dep(dep)
+        import click
+
+        if ok:
+            click.echo(f"  {msg}")
+        else:
+            click.echo(f"  Warning: {msg}", err=True)
+
+    # Install Python package
+    pip_cmd = _pip_target()
+    cmd = [*pip_cmd, "install", info["package"]]
+    if upgrade:
+        cmd.append("--upgrade")
+
+    import click
+
+    click.echo(f"Installing {info['package']}...")
+    subprocess.run(cmd, check=True)
+    click.echo(f"Done. '{name}' extra installed.")
+
+
+def list_extras(as_json: bool = False) -> None:
+    """Print install status for all extras."""
+    import click
+
+    status = extra_status()
+    if as_json:
+        click.echo(json.dumps({k: {"installed": v, **EXTRAS[k]} for k, v in status.items()}))
+        return
+
+    for name, installed in status.items():
+        icon = "✓" if installed else "✗"
+        desc = EXTRAS[name]["description"]
+        hint = "" if installed else f"   → wst install {name}"
+        click.echo(f"  {icon}  {name:<10} {desc}{hint}")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,134 @@
+"""Tests for wst install command and install module."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from wst.cli import cli
+from wst.install import EXTRAS, extra_status, is_module_available
+
+# ---------------------------------------------------------------------------
+# extra_status / is_module_available
+# ---------------------------------------------------------------------------
+
+
+def test_is_module_available_stdlib():
+    assert is_module_available("os") is True
+
+
+def test_is_module_available_missing():
+    assert is_module_available("_nonexistent_module_xyz") is False
+
+
+def test_extra_status_topics_installed():
+    status = extra_status()
+    assert "ocr" in status
+    assert "topics" in status
+    assert isinstance(status["ocr"], bool)
+    assert isinstance(status["topics"], bool)
+
+
+# ---------------------------------------------------------------------------
+# CLI: wst install --list
+# ---------------------------------------------------------------------------
+
+
+def test_install_list_human():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install", "--list"])
+    assert result.exit_code == 0
+    assert "ocr" in result.output
+    assert "topics" in result.output
+
+
+def test_install_list_json():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install", "--list", "--json"])
+    assert result.exit_code == 0
+    import json
+
+    data = json.loads(result.output)
+    assert set(data.keys()) == set(EXTRAS.keys())
+    for v in data.values():
+        assert "installed" in v
+        assert "description" in v
+
+
+def test_install_no_args_shows_list():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install"])
+    assert result.exit_code == 0
+    assert "ocr" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: wst install <extra>
+# ---------------------------------------------------------------------------
+
+
+def test_install_unknown_extra():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install", "unknown_extra"])
+    assert result.exit_code != 0
+    assert "unknown_extra" in result.output.lower() or "unknown_extra" in result.output
+
+
+@patch("wst.install.install_extra")
+def test_install_ocr_calls_install_extra(mock_install):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install", "ocr"])
+    assert result.exit_code == 0
+    mock_install.assert_called_once_with("ocr", upgrade=False)
+
+
+@patch("wst.install.install_extra")
+def test_install_upgrade_flag(mock_install):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install", "ocr", "--upgrade"])
+    assert result.exit_code == 0
+    mock_install.assert_called_once_with("ocr", upgrade=True)
+
+
+# ---------------------------------------------------------------------------
+# inject_sidecar_path — no-op when not frozen
+# ---------------------------------------------------------------------------
+
+
+def test_inject_sidecar_path_noop_when_not_frozen():
+    from wst.install import inject_sidecar_path
+
+    original_path = sys.path.copy()
+    inject_sidecar_path()
+    assert sys.path == original_path
+
+
+# ---------------------------------------------------------------------------
+# install_extra — mocked subprocess
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("wst.install._check_sys_dep", return_value=True)
+def test_install_extra_runs_pip(mock_sys_dep, mock_run):
+    mock_run.return_value = MagicMock(returncode=0)
+    from wst.install import install_extra
+
+    install_extra("topics")
+    # Should call pip install
+    calls = [str(c) for c in mock_run.call_args_list]
+    assert any("topics" in c or "wst-library" in c for c in calls)
+
+
+@patch("subprocess.run")
+@patch("wst.install._check_sys_dep", return_value=False)
+@patch("wst.install._install_sys_dep_macos", return_value=False)
+@patch("wst.install._install_sys_dep_linux", return_value=False)
+def test_install_extra_warns_on_missing_sys_dep(mock_linux, mock_mac, mock_check, mock_run):
+    mock_run.return_value = MagicMock(returncode=0)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["install", "ocr"])
+    # Should still proceed (warning only), not error
+    assert result.exit_code == 0


### PR DESCRIPTION
Closes #22

This PR contains RFC 0008 proposing a `wst install <extra>` command and a Tauri app Extras panel.

**The problem**: Installing OCR and topic modeling packages requires manual `pip install` commands. Non-technical users hitting the Tauri app have no guidance when a feature fails because an optional package is missing.

**The proposal**: A `wst install ocr|topics` command that installs into the current Python environment, plus a Settings/Extras section in the Tauri app that shows install status and triggers installations with streaming output.

## What's in this PR (RFC phase)

- `docs/rfcs/0008-install-extras-command.md` — full design with CLI interface, Tauri UI approach, and bundled-binary strategy

## Before I implement

Please review the RFC and leave a comment here (or on issue #22) with one of:
- ✅ **approved** — I'll add the implementation to this PR
- 🔁 **changes: \<what to change\>** — I'll revise the RFC accordingly

The key decision point is **Q1**: bundle all extras in the PyInstaller binary (simpler UX) vs a side-car venv (lean bundle).