### PR TITLE
RFC: Auto-release bug fixes (skip-ci leak + squash-bullet parser)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,8 +2,13 @@ name: Auto Release
 
 # Fires on every push to main. Inspects the new commits via Conventional Commits
 # and, if any of them warrant a release, bumps pyproject.toml, commits the bump
-# with [skip ci], and pushes a vX.Y.Z tag. The tag push triggers
+# as github-actions[bot], and pushes a vX.Y.Z tag. The tag push triggers
 # release-on-tag.yml, which builds and publishes artifacts.
+#
+# Recursion is prevented by the actor + subject guard on the bump job (see below) —
+# we deliberately do NOT use GitHub's CI-skip directive token, because it can leak
+# from prose in unrelated commit messages and silently disable all workflows.
+# See README's Releasing section.
 #
 # Bump rules:
 #   feat:  / feat!: / BREAKING CHANGE   -> minor
@@ -25,9 +30,9 @@ jobs:
   bump:
     runs-on: ubuntu-latest
 
-    # Recursion guard #1: skip the bump commit this workflow itself produced.
-    # [skip ci] in the commit message is the primary defense; this is belt-and-suspenders
-    # in case [skip ci] semantics change.
+    # Recursion guard: skip the bump commit this workflow itself produced.
+    # The actor + subject prefix combination uniquely identifies our own bump
+    # commit and is mechanically safe (no reliance on commit-message tokens).
     if: |
       !(github.actor == 'github-actions[bot]'
         && startsWith(github.event.head_commit.message, 'chore: bump version to'))
@@ -51,8 +56,11 @@ jobs:
             exit 0
           fi
 
-          # First-line of every commit subject in the push.
-          MESSAGES=$(git log --format='%s%n%b%n---' "$BEFORE..$AFTER")
+          # First-line of every commit subject in the push, with squash-merge
+          # bullets ("* ") stripped so Conventional-Commits prefixes anchor to
+          # the start of the line.
+          MESSAGES=$(git log --format='%s%n%b%n---' "$BEFORE..$AFTER" \
+            | sed 's/^[[:space:]]*\* //')
           echo "Inspecting commits in $BEFORE..$AFTER"
           echo "$MESSAGES"
 
@@ -101,7 +109,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git add pyproject.toml
-          git commit -m "chore: bump version to $NEXT [skip ci]"
+          git commit -m "chore: bump version to $NEXT"
           git tag "v$NEXT" -m "Release v$NEXT"
 
           git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ Releases are automatic. Use [Conventional Commits](https://www.conventionalcommi
 | `fix:` / `perf:` | patch bump (e.g. `0.10.3` → `0.10.4`) |
 | `refactor:` / `chore:` / `docs:` / `rfc:` / `test:` / `style:` / `ci:` | no release |
 
-On a qualifying merge, `auto-release.yml` bumps `pyproject.toml`, commits the bump as `github-actions[bot]` with `[skip ci]`, and pushes a `vX.Y.Z` tag. The tag push then triggers `release-on-tag.yml`, which runs tests, builds the macOS `.dmg`, publishes to PyPI, optionally pushes to Chocolatey, and attaches all artifacts to a GitHub Release.
+On a qualifying merge, `auto-release.yml` bumps `pyproject.toml`, commits the bump as `github-actions[bot]`, and pushes a `vX.Y.Z` tag. Recursion is prevented by an actor + subject guard on the bump job, not by the GitHub CI-skip directive. The tag push then triggers `release-on-tag.yml`, which runs tests, builds the macOS `.dmg`, publishes to PyPI, optionally pushes to Chocolatey, and attaches all artifacts to a GitHub Release.
+
+> **Heads-up:** never include the literal CI-skip token (open bracket, `skip` `ci`, close bracket — described, not spelled, here so this README itself doesn't trip it) in commit messages or PR descriptions for changes that should run CI. GitHub honors that token on **any line** of a commit message and silently skips every workflow. If you need to refer to it in prose, hyphenate it (`[skip-ci]`) or wrap it in inline code that the squash-merge will preserve as backticks.
 
 Pre-1.0: `BREAKING CHANGE:` bumps minor (no major bumps until `1.0.0`).
 

--- a/docs/rfcs/0010-auto-release-bug-fixes.md
+++ b/docs/rfcs/0010-auto-release-bug-fixes.md
@@ -1,8 +1,12 @@
 # RFC 0010: Auto-release bug fixes (skip-ci leak + squash-bullet parser)
 
 **Issue**: #27
-**Status**: Draft — awaiting approval
+**Status**: Approved — awaiting implementation
 **Branch**: `rfc/27-skip-ci-and-squash-parser`
+
+**Resolutions** (from #27 comments):
+- **Q1**: Drop `[skip ci]` entirely; rely on the actor+message guard.
+- **Q2**: Manually push `v0.11.0` at `ad48d8c` to ship #26's intended smoke-test release.
 
 ---
 
@@ -80,18 +84,10 @@ Add a one-paragraph note to the `Releasing` section of `README.md`: *"Don't incl
 
 ---
 
-## Open Questions
-
-> **Q1**: Drop `[skip ci]` from the bump commit message entirely (relying on the actor+message guard alone), or keep it as belt-and-suspenders and just be careful in prose? My recommendation is **drop it** — fewer footguns, and the actor guard is mechanically reliable.
-
-> **Q2**: Should this RFC also push a manual `v0.11.0` tag at `ad48d8c` to ship the artifacts that #26's smoke test was supposed to produce? Or wait for the next real `feat:`/`fix:` merge (after these fixes ship) to be the smoke test? Pushing `v0.11.0` now ships v0.11.0 with the new bump-and-release pipeline live — that's the cleanest validation. Waiting means v0.11.0 is whatever the next merge bumps to, which loses the symmetry of "the PR that introduced auto-release is the one that produced v0.11.0."
-
----
-
 ## Implementation Plan
 
 - [ ] Add `sed 's/^[[:space:]]*\* //'` strip to the `Determine bump kind from commits` step in `auto-release.yml`.
-- [ ] Remove `[skip ci]` from the bump commit message (depends on Q1).
+- [ ] Remove `[skip ci]` from the bump commit message; keep the `github-actions[bot]` actor + `chore: bump version to` subject guard as the sole recursion check.
 - [ ] Update `README.md`'s Releasing section with the no-`[skip ci]`-in-prose note.
-- [ ] (Depends on Q2) Manually push `v0.11.0` at `ad48d8c` to ship #26's intended smoke-test release.
+- [ ] After the fixes merge, manually push `v0.11.0` at `ad48d8c` (or the merge commit of this PR if a fresh tag is cleaner) to validate the end-to-end bump-and-release pipeline by shipping #26's intended smoke-test release.
 - [ ] Smoke-test by including a tiny `fix:` commit alongside the parser fix in this PR's merge — once `auto-release.yml` is patched, the merge of *this* PR should auto-bump (patch).

--- a/docs/rfcs/0010-auto-release-bug-fixes.md
+++ b/docs/rfcs/0010-auto-release-bug-fixes.md
@@ -1,7 +1,7 @@
 # RFC 0010: Auto-release bug fixes (skip-ci leak + squash-bullet parser)
 
 **Issue**: #27
-**Status**: Approved — awaiting implementation
+**Status**: Implementing
 **Branch**: `rfc/27-skip-ci-and-squash-parser`
 
 **Resolutions** (from #27 comments):

--- a/docs/rfcs/0010-auto-release-bug-fixes.md
+++ b/docs/rfcs/0010-auto-release-bug-fixes.md
@@ -1,0 +1,97 @@
+# RFC 0010: Auto-release bug fixes (skip-ci leak + squash-bullet parser)
+
+**Issue**: #27
+**Status**: Draft — awaiting approval
+**Branch**: `rfc/27-skip-ci-and-squash-parser`
+
+---
+
+## Problem
+
+Two bugs in `auto-release.yml` (introduced in #25 / commit `ad48d8c`) caused the smoke-test release to silently fail:
+
+### Bug 1 — `[skip ci]` leaked from prose into a real commit message
+
+PR #26's squash-merge commit body contains the literal string `[skip ci]` in an explanatory sentence: *"commit as github-actions[bot] with `[skip ci]`, push vX.Y.Z tag."* GitHub honors `[skip ci]` on **any line** of the commit message. Result: zero workflows fired for `ad48d8c` — neither `Auto Release` nor `CI`.
+
+This will keep happening any time prose about the workflow's behavior gets squashed into a real commit message.
+
+### Bug 2 — Conventional-Commits parser doesn't handle squash-merge bullets
+
+`auto-release.yml` greps for `^(feat|fix|perf)…:` against `git log --format='%s%n%b%n---' BEFORE..AFTER`. GitHub's "Squash and merge" produces a commit with each squashed source commit prefixed with `* `:
+
+```
+RFC: Reliable releases on merge to main (#26)
+
+* rfc: reliable releases on merge to main (#25)
+* rfc: address review feedback (#25)
+* feat(ci): auto-bump version on merge via Conventional Commits
+   …body…
+```
+
+The `^` anchor never matches the bulleted line because of the leading `* `. The squash subject (`RFC: …`) doesn't match either. So even if Bug 1 hadn't fired, no version bump would have happened.
+
+---
+
+## Proposed Solution
+
+Two small changes to `auto-release.yml`, plus a project-wide convention.
+
+### Fix 1 — Strip `* ` bullets before grepping (and broaden the prefix scan)
+
+Pre-process the commit messages to remove leading `* ` (squash-merge bullet) and leading whitespace, then run the same regex:
+
+```bash
+MESSAGES=$(git log --format='%s%n%b%n---' "$BEFORE..$AFTER" \
+  | sed 's/^[[:space:]]*\* //')
+```
+
+After the strip, both `* feat(ci): …` and a plain `feat(ci): …` line match `^(feat|fix|perf)…`.
+
+### Fix 2 — Recognize non-literal `[skip ci]` mentions safely
+
+Two layers, defense-in-depth:
+
+1. **Don't put `[skip ci]` in any commit message we don't actually want skipped.** Update PR templates / RFC writing guidance to escape the token in prose: write it as `[skip-ci]` (hyphenated) or wrap it in a code fence the squash strips out, or simply spell it differently in narrative ("the workflow appends a CI-skip directive").
+2. **Workflow-level guard:** before triggering a release, the workflow can re-check the head commit message for an *unintended* `[skip ci]`. There is no clean way to tell intent apart from accident inside the workflow itself, so the only mechanically-safe option is **stop using `[skip ci]` for the auto-bump commit** — switch to the actor-+-message recursion guard alone:
+
+```yaml
+if: |
+  !(github.actor == 'github-actions[bot]'
+    && startsWith(github.event.head_commit.message, 'chore: bump version to'))
+```
+
+The actor check is sufficient on its own — `github-actions[bot]` only authors the bump commit, and the subject prefix is unique. Removing `[skip ci]` from the bump commit message means we no longer have to worry about *anyone* accidentally quoting that token in any future commit.
+
+### Convention
+
+Add a one-paragraph note to the `Releasing` section of `README.md`: *"Don't include the literal token `[skip ci]` (with brackets and a space) in commit messages or PR descriptions for changes that should run CI. GitHub interprets it anywhere in the message and silently skips all workflows."*
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Keep `[skip ci]` on the bump commit AND the actor guard, just escape the token in prose | The escape is fragile — relies on every future contributor (and Claude) to remember. The actor guard alone is just as safe. |
+| Detect `[skip ci]` in commit body via a pre-flight workflow that fails noisily | Doesn't help: GitHub already swallows the workflow before the pre-flight runs. |
+| Switch from "Squash and merge" to "Rebase and merge" or "Create a merge commit" | Bigger workflow change; would also lose the clean per-PR commit summary. The bullet-strip fix is one line of `sed`. |
+| Require all PR titles to start with a Conventional-Commits prefix | Reasonable hygiene but doesn't help RFC PRs that don't ship code (`RFC:` is a perfectly valid title for a doc-only PR). The bullet-strip fix removes the reliance on PR-title convention. |
+
+---
+
+## Open Questions
+
+> **Q1**: Drop `[skip ci]` from the bump commit message entirely (relying on the actor+message guard alone), or keep it as belt-and-suspenders and just be careful in prose? My recommendation is **drop it** — fewer footguns, and the actor guard is mechanically reliable.
+
+> **Q2**: Should this RFC also push a manual `v0.11.0` tag at `ad48d8c` to ship the artifacts that #26's smoke test was supposed to produce? Or wait for the next real `feat:`/`fix:` merge (after these fixes ship) to be the smoke test? Pushing `v0.11.0` now ships v0.11.0 with the new bump-and-release pipeline live — that's the cleanest validation. Waiting means v0.11.0 is whatever the next merge bumps to, which loses the symmetry of "the PR that introduced auto-release is the one that produced v0.11.0."
+
+---
+
+## Implementation Plan
+
+- [ ] Add `sed 's/^[[:space:]]*\* //'` strip to the `Determine bump kind from commits` step in `auto-release.yml`.
+- [ ] Remove `[skip ci]` from the bump commit message (depends on Q1).
+- [ ] Update `README.md`'s Releasing section with the no-`[skip ci]`-in-prose note.
+- [ ] (Depends on Q2) Manually push `v0.11.0` at `ad48d8c` to ship #26's intended smoke-test release.
+- [ ] Smoke-test by including a tiny `fix:` commit alongside the parser fix in this PR's merge — once `auto-release.yml` is patched, the merge of *this* PR should auto-bump (patch).


### PR DESCRIPTION
Closes #27

RFC + implementation for #27. Two bugs in `auto-release.yml` (introduced in #25 / `ad48d8c`) caused the smoke-test release to silently fail.

**Bug 1 fix:** the auto-bump commit no longer uses GitHub's CI-skip directive. Recursion is prevented by the `github-actions[bot]` actor + `chore: bump version to` subject guard alone (mechanically reliable, no risk of accidental token occurrences in unrelated commit messages).

**Bug 2 fix:** strip leading `* ` (squash-merge bullets) before grepping for Conventional-Commits prefixes — this was why `ad48d8c`'s squashed `feat(ci):` line wasn't picked up.

**Convention:** README note about not putting the literal CI-skip token in prose for commit messages / PR descriptions.

Resolutions captured in the RFC frontmatter (Q1: drop directive entirely; Q2: manually push `v0.11.0` post-merge).

> **Note for the merger:** when squashing, ensure the merge commit body does not contain the literal CI-skip token (open bracket, `skip` `ci`, close bracket). This PR description has been written to avoid it.

**To approve:** add the `approved` label to this PR.
