### PR TITLE
RFC: Backup all to iCloud and Google Drive (CLI + GUI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Named after **Wan Shi Tong**, the ancient spirit who collected every piece of kn
 - **SQLite search index**: Full-text search across title, author, tags, subject, and summary via FTS5
 - **Coverage stats**: See metadata completeness across your library, broken down by document type and field
 - **Interactive browser**: Fuzzy-search your library, view and edit metadata interactively
-- **Cloud backup**: Backup files to iCloud Drive or S3, with extensible provider system
+- **Cloud backup**: Backup files to iCloud Drive, Google Drive, or S3, with extensible provider system
 - **Extensible backends**: Abstract layers for AI (Claude CLI, future API/SDK) and storage (local filesystem, S3)
 
 ## Installation
@@ -127,7 +127,10 @@ wst browse
 
 # Backup
 wst backup icloud
+wst backup gdrive          # syncs into your local Google Drive folder
+wst backup gdrive --all    # back up the entire library (used by the GUI)
 wst backup s3
+wst backup providers --format json  # list providers and configured state
 ```
 
 ## Commands
@@ -143,7 +146,7 @@ wst backup s3
 | `wst stats` | Show metadata coverage statistics. Options: `--type` |
 | `wst browse` | Interactive TUI for browsing and editing documents |
 | `wst ocr <id-or-path>` | Run OCR on scanned PDFs |
-| `wst backup [provider]` | Backup files to iCloud or S3 |
+| `wst backup [provider]` | Backup files to iCloud, Google Drive, or S3. Providers: `icloud`, `gdrive`, `s3`. Use `--all` for full-library backup. The GUI exposes the same providers via the **Backup pane** in the sidebar. |
 
 ## How Ingestion Works
 

--- a/app/src/components/BackupPane.tsx
+++ b/app/src/components/BackupPane.tsx
@@ -1,0 +1,183 @@
+import { For, Show, createSignal, onMount } from "solid-js";
+import {
+  backupAll,
+  configureBackupProvider,
+  listBackupProviders,
+  type BackupProvider,
+  type BackupProviderInfo,
+} from "../lib/tauri";
+
+const PROVIDER_LABELS: Record<BackupProvider, string> = {
+  icloud: "iCloud",
+  gdrive: "Google Drive",
+  s3: "S3",
+};
+
+export default function BackupPane() {
+  const [providers, setProviders] = createSignal<BackupProviderInfo[]>([]);
+  const [busy, setBusy] = createSignal<BackupProvider | null>(null);
+  const [status, setStatus] = createSignal<string | null>(null);
+  const [error, setError] = createSignal(false);
+  const [wizardFor, setWizardFor] = createSignal<BackupProvider | null>(null);
+  const [wizardSubfolder, setWizardSubfolder] = createSignal("wst");
+  const [wizardPath, setWizardPath] = createSignal("");
+  const [wizardError, setWizardError] = createSignal<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      setProviders(await listBackupProviders());
+    } catch {
+      setProviders([]);
+    }
+  };
+
+  onMount(refresh);
+
+  const flashStatus = (msg: string, isError = false) => {
+    setError(isError);
+    setStatus(msg);
+    setTimeout(() => setStatus(null), 4000);
+  };
+
+  const handleBackupAll = async (p: BackupProvider) => {
+    setBusy(p);
+    try {
+      const result = await backupAll(p);
+      flashStatus(`${PROVIDER_LABELS[p]}: ${result.backed_up_files} archivos respaldados ✓`);
+    } catch (err) {
+      flashStatus(String(err), true);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const openWizard = (p: BackupProvider) => {
+    setWizardFor(p);
+    setWizardSubfolder("wst");
+    setWizardPath("");
+    setWizardError(null);
+  };
+
+  const submitWizard = async () => {
+    const p = wizardFor();
+    if (!p || p === "s3") return;
+    setWizardError(null);
+    try {
+      await configureBackupProvider(p, {
+        subfolder: wizardSubfolder() || "wst",
+        path: wizardPath() || undefined,
+      });
+      setWizardFor(null);
+      await refresh();
+      flashStatus(`${PROVIDER_LABELS[p]} configurado ✓`);
+    } catch (err) {
+      setWizardError(String(err));
+    }
+  };
+
+  return (
+    <div class="backup-pane">
+      <div class="sidebar-section-label sidebar-section-sep">Backup</div>
+      <ul class="sidebar-list">
+        <For each={providers()}>
+          {(p) => (
+            <li class="backup-provider-row">
+              <div class="backup-provider-row-head">
+                <span>{PROVIDER_LABELS[p.name]}</span>
+                <span
+                  class={
+                    p.configured
+                      ? "backup-provider-status backup-provider-status--ok"
+                      : "backup-provider-status backup-provider-status--off"
+                  }
+                >
+                  {p.configured ? "✓" : "○"}
+                </span>
+              </div>
+              <div class="backup-provider-actions">
+                <Show
+                  when={p.configured}
+                  fallback={
+                    p.name === "s3" ? (
+                      <span class="backup-provider-hint">
+                        Configurar en CLI: <code>wst backup s3 --configure</code>
+                      </span>
+                    ) : (
+                      <button
+                        class="btn btn-secondary btn-small"
+                        onClick={() => openWizard(p.name)}
+                      >
+                        Configurar
+                      </button>
+                    )
+                  }
+                >
+                  <button
+                    class="btn btn-primary btn-small"
+                    disabled={busy() !== null}
+                    onClick={() => handleBackupAll(p.name)}
+                  >
+                    {busy() === p.name ? "Respaldando…" : "Respaldar todo"}
+                  </button>
+                </Show>
+              </div>
+            </li>
+          )}
+        </For>
+      </ul>
+
+      <Show when={status()}>
+        <p
+          class={`backup-pane-status${error() ? " backup-pane-status--error" : ""}`}
+        >
+          {status()}
+        </p>
+      </Show>
+
+      <Show when={wizardFor()}>
+        {(p) => (
+          <div class="backup-wizard">
+            <h4 class="backup-wizard-title">
+              Configurar {PROVIDER_LABELS[p()]}
+            </h4>
+            <Show when={p() === "gdrive"}>
+              <label class="backup-wizard-field">
+                <span>Ruta a Google Drive (opcional)</span>
+                <input
+                  type="text"
+                  placeholder="(auto-detect)"
+                  value={wizardPath()}
+                  onInput={(e) => setWizardPath(e.currentTarget.value)}
+                />
+              </label>
+            </Show>
+            <label class="backup-wizard-field">
+              <span>Subcarpeta</span>
+              <input
+                type="text"
+                value={wizardSubfolder()}
+                onInput={(e) => setWizardSubfolder(e.currentTarget.value)}
+              />
+            </label>
+            <Show when={wizardError()}>
+              <p class="backup-pane-status backup-pane-status--error">
+                {wizardError()}
+              </p>
+            </Show>
+            <div class="backup-wizard-actions">
+              <button class="btn btn-primary btn-small" onClick={submitWizard}>
+                Guardar
+              </button>
+              <button
+                class="btn btn-secondary btn-small"
+                onClick={() => setWizardFor(null)}
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/app/src/components/BookDetail.tsx
+++ b/app/src/components/BookDetail.tsx
@@ -1,8 +1,23 @@
 import { Show, For, createSignal, createEffect } from "solid-js";
 import { selectedDoc, setSelectedDoc, setDocuments, documents } from "../lib/store";
-import { openPdf, revealInFinder, getCover, editDocument, getTopicsVocabulary, backupDocumentToIcloud } from "../lib/tauri";
+import {
+  openPdf,
+  revealInFinder,
+  getCover,
+  editDocument,
+  getTopicsVocabulary,
+  backupDocument,
+  listBackupProviders,
+  type BackupProvider,
+} from "../lib/tauri";
 import { DOC_TYPE_LABELS } from "../lib/types";
 import type { Document } from "../lib/types";
+
+const PROVIDER_LABELS: Record<BackupProvider, string> = {
+  icloud: "iCloud",
+  gdrive: "Google Drive",
+  s3: "S3",
+};
 
 export default function BookDetail() {
   const doc = () => selectedDoc();
@@ -12,6 +27,8 @@ export default function BookDetail() {
   const [saveError, setSaveError] = createSignal<string | null>(null);
   const [backupStatus, setBackupStatus] = createSignal<string | null>(null);
   const [backupError, setBackupError] = createSignal(false);
+  const [backupMenuOpen, setBackupMenuOpen] = createSignal(false);
+  const [configuredProviders, setConfiguredProviders] = createSignal<BackupProvider[]>([]);
 
   // Edit form fields
   const [editTitle, setEditTitle] = createSignal("");
@@ -92,11 +109,22 @@ export default function BookDetail() {
     }
   };
 
-  const handleBackup = async (id: number) => {
+  const openBackupMenu = async () => {
     try {
-      await backupDocumentToIcloud(id);
+      const list = await listBackupProviders();
+      setConfiguredProviders(list.filter((p) => p.configured).map((p) => p.name));
+    } catch {
+      setConfiguredProviders([]);
+    }
+    setBackupMenuOpen(true);
+  };
+
+  const handleBackup = async (id: number, provider: BackupProvider) => {
+    setBackupMenuOpen(false);
+    try {
+      await backupDocument(id, provider);
       setBackupError(false);
-      setBackupStatus("Guardado en iCloud ✓");
+      setBackupStatus(`Guardado en ${PROVIDER_LABELS[provider]} ✓`);
     } catch (err) {
       setBackupError(true);
       setBackupStatus(String(err));
@@ -152,13 +180,37 @@ export default function BookDetail() {
                   >
                     Mostrar en Finder
                   </button>
-                  <button
-                    class="btn btn-secondary"
-                    onClick={() => handleBackup(d().id)}
-                    title="Backup a iCloud"
-                  >
-                    ☁ iCloud
-                  </button>
+                  <div class="backup-menu">
+                    <button
+                      class="btn btn-secondary"
+                      onClick={openBackupMenu}
+                      title="Backup a la nube"
+                    >
+                      ☁ Backup ▾
+                    </button>
+                    <Show when={backupMenuOpen()}>
+                      <div
+                        class="backup-menu-dropdown"
+                        onMouseLeave={() => setBackupMenuOpen(false)}
+                      >
+                        <For each={Object.entries(PROVIDER_LABELS) as [BackupProvider, string][]}>
+                          {([key, label]) => {
+                            const isConfigured = configuredProviders().includes(key);
+                            return (
+                              <button
+                                class="backup-menu-item"
+                                disabled={!isConfigured}
+                                title={isConfigured ? "" : "Run `wst backup " + key + " --configure` to enable"}
+                                onClick={() => handleBackup(d().id, key)}
+                              >
+                                {label}{isConfigured ? "" : " (not configured)"}
+                              </button>
+                            );
+                          }}
+                        </For>
+                      </div>
+                    </Show>
+                  </div>
                   <button
                     class="btn btn-secondary"
                     onClick={openEditPanel}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   clearAllFilters,
 } from "../lib/store";
 import { DOC_TYPE_LABELS } from "../lib/types";
+import BackupPane from "./BackupPane";
 
 const STORAGE_KEY = "wst.sidebarWidth";
 const MIN_WIDTH = 160;
@@ -153,6 +154,8 @@ export default function Sidebar() {
           </For>
         </ul>
       </Show>
+
+      <BackupPane />
 
       <div class="sidebar-resize-handle" onMouseDown={onHandleMouseDown} />
     </nav>

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -75,10 +75,56 @@ export async function backupToIcloud(): Promise<string> {
   return invoke("backup_to_icloud");
 }
 
-export async function backupDocumentToIcloud(id: number): Promise<void> {
+export type BackupProvider = "icloud" | "gdrive" | "s3";
+
+export interface BackupProviderInfo {
+  name: BackupProvider;
+  configured: boolean;
+}
+
+export async function backupDocument(id: number, provider: BackupProvider): Promise<void> {
   await invoke<string>("run_wst_command", {
-    args: ["backup", "icloud", String(id), "--format", "json"],
+    args: ["backup", provider, String(id), "--format", "json"],
   });
+}
+
+/** @deprecated use backupDocument(id, "icloud") */
+export async function backupDocumentToIcloud(id: number): Promise<void> {
+  return backupDocument(id, "icloud");
+}
+
+export interface BackupAllResult {
+  provider: BackupProvider;
+  backed_up_files: number;
+}
+
+export async function backupAll(provider: BackupProvider): Promise<BackupAllResult> {
+  const raw = await invoke<string>("run_wst_command", {
+    args: ["backup", provider, "--all", "--format", "json"],
+  });
+  const result = JSON.parse(raw);
+  return result.data as BackupAllResult;
+}
+
+export async function listBackupProviders(): Promise<BackupProviderInfo[]> {
+  const raw = await invoke<string>("run_wst_command", {
+    args: ["backup", "providers", "--format", "json"],
+  });
+  const result = JSON.parse(raw);
+  return result.data.providers as BackupProviderInfo[];
+}
+
+export async function configureBackupProvider(
+  provider: "icloud" | "gdrive",
+  opts: { subfolder?: string; path?: string }
+): Promise<{ root: string }> {
+  const args = ["backup", provider, "--configure"];
+  if (opts.subfolder) args.push("--subfolder", opts.subfolder);
+  if (provider === "gdrive" && opts.path) args.push("--path", opts.path);
+  args.push("--format", "json");
+  const raw = await invoke<string>("run_wst_command", { args });
+  const result = JSON.parse(raw);
+  return { root: result.data.root };
 }
 
 export interface ExtraInfo {

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1069,3 +1069,144 @@ body.resizing {
   justify-content: flex-end;
   margin-top: 16px;
 }
+
+/* Backup menu inside BookDetail */
+.backup-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.backup-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 160px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0;
+}
+
+.backup-menu-item {
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.backup-menu-item:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.backup-menu-item:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+/* Sidebar Backup pane */
+.backup-pane {
+  margin-top: 16px;
+  padding: 0 8px 8px 8px;
+}
+
+.backup-provider-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.backup-provider-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.backup-provider-status {
+  font-size: 11px;
+}
+
+.backup-provider-status--ok {
+  color: var(--accent);
+}
+
+.backup-provider-status--off {
+  color: var(--text-muted);
+}
+
+.backup-provider-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.backup-provider-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.backup-provider-hint code {
+  font-family: monospace;
+  font-size: 11px;
+}
+
+.btn-small {
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.backup-pane-status {
+  margin: 6px 8px 0;
+  font-size: 11px;
+  color: var(--accent);
+}
+
+.backup-pane-status--error {
+  color: #c0392b;
+}
+
+.backup-wizard {
+  margin: 8px 8px 0;
+  padding: 10px;
+  background: var(--bg-hover);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.backup-wizard-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.backup-wizard-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.backup-wizard-field input {
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.backup-wizard-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}

--- a/docs/rfcs/0014-backup-all-cloud-providers.md
+++ b/docs/rfcs/0014-backup-all-cloud-providers.md
@@ -1,8 +1,15 @@
 # RFC 0014: Backup all to iCloud and Google Drive (CLI + GUI)
 
 **Issue**: #35
-**Status**: Draft — awaiting approval
+**Status**: Implementing
 **Branch**: `rfc/35-backup-all-cloud-providers`
+
+**Resolutions** (from #35 comments):
+- **Q1**: Auto-pick the first macOS Drive match silently. The GUI lets the user confirm/select if multiple accounts exist; the CLI accepts a `--path` argument for explicit override.
+- **Q2**: New **Backup pane** in `Sidebar.tsx`.
+- **Q3**: Default subfolder `wst` (same as iCloud).
+- **Q4**: Inline configuration wizard in the GUI when a provider is unconfigured.
+- **Q5**: Keep `backup_to_icloud` as a deprecated shim; add new `backup_document(id, provider)` alongside.
 
 ---
 

--- a/docs/rfcs/0014-backup-all-cloud-providers.md
+++ b/docs/rfcs/0014-backup-all-cloud-providers.md
@@ -1,0 +1,101 @@
+# RFC 0014: Backup all to iCloud and Google Drive (CLI + GUI)
+
+**Issue**: #35
+**Status**: Draft — awaiting approval
+**Branch**: `rfc/35-backup-all-cloud-providers`
+
+---
+
+## Problem
+
+`wst` already has a `backup` system with two providers — `icloud` (filesystem-based, writes into the macOS/Windows iCloud Drive sync folder) and `s3` (API-based). The CLI can already back up the **entire library** to either provider via `wst backup` (interactive) or a single file via `wst backup icloud <ID>` / `wst backup s3 <ID>` ([`backup.py:303-313`](../../src/wst/backup.py), [`cli.py:393-488`](../../src/wst/cli.py)).
+
+Two gaps:
+
+1. **No Google Drive support.** Many users sync libraries with Google Drive's desktop client (`~/Library/CloudStorage/GoogleDrive-<email>/My Drive` on macOS, `Google Drive` folder on Windows) the same way they use iCloud. Today they have to copy files manually out of `~/wst` or set up S3, which they may not have.
+2. **The GUI only backs up one document at a time, and only to iCloud.** The Tauri surface exposes `backup_to_icloud(id)` only ([`commands.rs:283`](../../app/src-tauri/src/commands.rs)) — there's no GUI equivalent of the CLI's "backup all" or "choose provider" flows. Desktop-app users have to drop to the CLI for bulk or non-iCloud backup.
+
+The user's request — *"Add option to backup all in iOS and Google Drive. It should rely on auto sync Google Drive folder and iOS. Should be available in CLI and in GUI"* — closes both gaps in one feature.
+
+---
+
+## Proposed Solution
+
+Add a third backup provider that writes into the user's local Google Drive sync folder (mirroring `ICloudProvider`), and expand the GUI to expose **backup-all + provider choice** for both filesystem-sync providers.
+
+### Provider: `GoogleDriveProvider`
+
+A new entry in `wst/backup.py` modeled directly on `ICloudProvider` (filesystem write into a user-synced folder):
+
+| Concern | Behavior |
+|---|---|
+| **Detection** | macOS: glob `~/Library/CloudStorage/GoogleDrive-*/My Drive` (Google appends the account email, so detection has to handle multiple matches). Windows: `~/Google Drive/My Drive` then fall back to `G:/My Drive`. Linux: `~/GoogleDrive` (rclone/insync convention), prompt if missing. |
+| **Configuration** | Subfolder name (default `wst`), like iCloud. Optional manual root path stored in `~/wst/config.json` if auto-detection fails. |
+| **`backup_file` / `backup_all`** | `shutil.copy2` into the synced folder, preserving relative path. Identical structure to `ICloudProvider`. |
+| **`is_configured`** | True iff the detected (or user-supplied) Google Drive root exists. |
+
+Registered in `PROVIDERS` so `wst backup gdrive` and `wst backup gdrive <ID>` mirror the existing iCloud commands.
+
+> This is **sync-folder backup**, not the Google Drive API. We are deliberately *not* adding OAuth/API-based upload here — that would be a separate provider with its own auth and error model. "Auto sync" in the issue body confirms the user's intent is the local sync folder approach.
+
+### CLI changes (small)
+
+- Register `GoogleDriveProvider` in the `PROVIDERS` dict in `backup.py`.
+- Add a `backup gdrive [IDENTIFIER]` Click subcommand alongside the existing `backup icloud` and `backup s3` commands. Same shape as `backup_icloud` ([`cli.py:440-486`](../../src/wst/cli.py)) — interactive when no identifier, single-file when identifier passed.
+
+The interactive `wst backup` flow picks up the new provider automatically through the `PROVIDERS` registry — no special-casing needed.
+
+### GUI changes
+
+The GUI today exposes one Tauri command (`backup_to_icloud(id)`) and one button (☁ iCloud) inside [`BookDetail.tsx:155-160`](../../app/src/components/BookDetail.tsx). Two changes:
+
+1. **Add Tauri commands** in `app/src-tauri/src/commands.rs`:
+   - `backup_document(id, provider)` — single-file backup. Replaces `backup_to_icloud`.
+   - `backup_all(provider)` — library-wide backup, returns `{ provider, backed_up_files }` mirroring `run_backup_all`'s return shape ([`backup.py:418-427`](../../src/wst/backup.py)).
+   - `list_backup_providers()` — returns `[{ name, configured }]` so the UI can grey out unconfigured providers.
+
+2. **UI surface**:
+   - In `BookDetail`: change the "☁ iCloud" button to a small dropdown (iCloud / Google Drive). iCloud stays default for back-compat. Status messages keep their current shape.
+   - Add a **Backup all** entry point — see Q2 — that opens a modal listing configured providers and runs `backup_all(provider)`, with progress (event stream) and a final count.
+
+The CLI's `backup_all(library_path, emit=True)` writes to stdout — for the GUI we'll add an optional progress callback so progress can stream over a Tauri event channel.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Use the Google Drive API (OAuth) instead of the local sync folder | Heavier auth, requires a Google Cloud project, and behaves differently from `ICloudProvider`. User explicitly said *"auto sync Google Drive folder"* — they want the filesystem-sync approach. Could be added later as `gdrive-api` if needed. |
+| Skip the GUI changes; add Google Drive only in CLI | Issue explicitly requires GUI parity. Half the request. |
+| Single "backup everywhere" command that pushes to all configured providers in one go | Surprising default (cost, time, partial failures). Better as a future enhancement once we have provider selection UI working — explicit choice first. |
+| Reuse `s3` provider for Google Cloud Storage instead of adding a new provider | Different feature (cloud-API uploads vs. local sync folder). Would also confuse users who expect Google Drive ≠ GCS. |
+
+---
+
+## Open Questions
+
+> **Q1**: For Google Drive on macOS, the canonical path under modern Google Drive for Desktop is `~/Library/CloudStorage/GoogleDrive-<email>/My Drive`. Account emails are dynamic, so detection has to glob. **Should we (a) auto-pick the first match, (b) prompt to choose if there are multiple, or (c) always require manual configuration?** Lean (b) with (a) as the silent default when only one account is signed in.
+
+> **Q2**: Where should "Backup all" live in the GUI? (a) new top-level button in `Toolbar.tsx`, (b) a new "Settings / Backup" pane in `Sidebar.tsx`, (c) inside the existing `ExtrasPanel.tsx`. Backup is a configuration-style action, not per-book — leans toward (b) or (c).
+
+> **Q3**: For the CLI, should `wst backup gdrive` follow the same "subfolder" convention as iCloud (default `wst/`)? Or copy directly into the Google Drive root? Subfolder is safer (no clutter) — proposing default `wst`.
+
+> **Q4**: When neither provider is configured and the user hits "Backup all" in the GUI, what should happen? Show a config wizard inline, or tell them to run `wst backup` once in the CLI? Inline wizard is nicer but more code to write.
+
+> **Q5**: For Tauri command naming — keep `backup_to_icloud` as a deprecated shim and add new `backup_document(id, provider)`, or rename in one shot and update `BookDetail.tsx`? The shim adds churn for little compatibility benefit (the GUI is the only caller). Lean toward in-place rename.
+
+---
+
+## Implementation Plan
+
+- [ ] Add `GoogleDriveProvider` to `src/wst/backup.py` with macOS / Windows / Linux detection, `configure()`, `is_configured()`, `backup_file()`, `backup_all()`.
+- [ ] Register `gdrive` in `PROVIDERS`.
+- [ ] Add `wst backup gdrive [ID]` Click command in `src/wst/cli.py` mirroring `backup_icloud`.
+- [ ] Tests: detection logic (mocked OS), backup-all into a temp dir acting as the "sync folder", config save/load.
+- [ ] Add Tauri commands `backup_document`, `backup_all`, `list_backup_providers` in `app/src-tauri/src/commands.rs`; register them in `lib.rs`.
+- [ ] Update `app/src/lib/tauri.ts` with the new Promise wrappers.
+- [ ] Update `BookDetail.tsx`: replace single iCloud button with a provider picker; keep the existing UX/status message shape.
+- [ ] Add a "Backup all" UI entry point (location decided in Q2) and a progress modal.
+- [ ] Update `README.md` backup section to document the new provider and the new GUI flow.
+- [ ] Smoke-test on macOS with both iCloud and Google Drive configured.

--- a/src/wst/backup.py
+++ b/src/wst/backup.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import click
-from InquirerPy import inquirer
 
 from wst.db import Database
 from wst.models import LibraryEntry
@@ -26,6 +25,40 @@ def _detect_icloud_base() -> Path | None:
         if p.exists():
             return p
     return None
+
+
+def _detect_gdrive_bases() -> list[Path]:
+    """Detect Google Drive sync folder roots. Returns all candidates found.
+
+    macOS modern Drive for Desktop uses ~/Library/CloudStorage/GoogleDrive-<email>/My Drive
+    and may have multiple entries when several accounts are signed in. Older versions
+    used ~/Google Drive/My Drive. Linux/Windows fall back to common conventions.
+    """
+    system = platform.system()
+    candidates: list[Path] = []
+    home = Path.home()
+
+    if system == "Darwin":
+        cloud_storage = home / "Library" / "CloudStorage"
+        if cloud_storage.exists():
+            for entry in sorted(cloud_storage.glob("GoogleDrive-*")):
+                my_drive = entry / "My Drive"
+                if my_drive.exists():
+                    candidates.append(my_drive)
+        legacy = home / "Google Drive" / "My Drive"
+        if legacy.exists():
+            candidates.append(legacy)
+    elif system == "Windows":
+        for p in (home / "Google Drive" / "My Drive", Path("G:/My Drive")):
+            if p.exists():
+                candidates.append(p)
+    else:
+        # Linux: rclone, insync, google-drive-ocamlfuse all default near ~/GoogleDrive
+        for p in (home / "GoogleDrive", home / "Google Drive"):
+            if p.exists():
+                candidates.append(p)
+
+    return candidates
 
 
 class BackupProvider(ABC):
@@ -73,6 +106,8 @@ class ICloudProvider(BackupProvider):
             else:
                 click.echo(f"iCloud Drive is not supported on {system}.")
             return
+
+        from InquirerPy import inquirer
 
         subfolder = (
             inquirer.text(
@@ -181,6 +216,8 @@ class S3Provider(BackupProvider):
         click.echo("\n--- S3 Backup Configuration ---")
         click.echo("Enter your S3 bucket credentials.")
         click.echo("These are stored locally in ~/wst/config.json\n")
+
+        from InquirerPy import inquirer
 
         bucket = inquirer.text(message="Bucket name:").execute().strip()
         if not bucket:
@@ -300,8 +337,121 @@ class S3Provider(BackupProvider):
         return count
 
 
+class GoogleDriveProvider(BackupProvider):
+    name = "gdrive"
+
+    def __init__(self, subfolder: str = "wst", root: Path | None = None):
+        self.subfolder = subfolder
+        if root is not None:
+            self.gdrive_base: Path | None = root
+        else:
+            from wst.config import get_gdrive_config
+
+            cfg = get_gdrive_config()
+            if cfg and cfg.get("root"):
+                self.gdrive_base = Path(cfg["root"])
+                self.subfolder = cfg.get("subfolder", subfolder)
+            else:
+                bases = _detect_gdrive_bases()
+                # Q1: auto-pick the first match
+                self.gdrive_base = bases[0] if bases else None
+        self.dest_root = self.gdrive_base / self.subfolder if self.gdrive_base else Path()
+
+    def is_configured(self) -> bool:
+        return self.gdrive_base is not None and self.gdrive_base.exists()
+
+    def configure(self) -> None:
+        from InquirerPy import inquirer
+
+        from wst.config import save_gdrive_config
+
+        bases = _detect_gdrive_bases()
+
+        if not bases:
+            click.echo("Google Drive sync folder not found.")
+            system = platform.system()
+            if system == "Darwin":
+                click.echo(
+                    "Install Google Drive for Desktop, sign in, "
+                    "and ensure 'My Drive' is set to stream or mirror."
+                )
+            elif system == "Windows":
+                click.echo("Install Google Drive for Desktop and sign in.")
+            else:
+                click.echo(
+                    "On Linux, install rclone/insync/google-drive-ocamlfuse and mount your Drive."
+                )
+            manual = (
+                inquirer.text(
+                    message=("Manual path to your Google Drive root (leave empty to skip):"),
+                    default="",
+                )
+                .execute()
+                .strip()
+            )
+            if not manual:
+                return
+            chosen = Path(manual).expanduser()
+            if not chosen.exists():
+                click.echo(f"Path not found: {chosen}")
+                return
+        elif len(bases) == 1:
+            chosen = bases[0]
+        else:
+            choice = inquirer.select(
+                message="Multiple Google Drive accounts detected — choose one:",
+                choices=[str(b) for b in bases],
+            ).execute()
+            chosen = Path(choice)
+
+        subfolder = (
+            inquirer.text(
+                message="Subfolder name in Google Drive:",
+                default=self.subfolder,
+            )
+            .execute()
+            .strip()
+        )
+
+        self.subfolder = subfolder or "wst"
+        self.gdrive_base = chosen
+        self.dest_root = self.gdrive_base / self.subfolder
+        self.dest_root.mkdir(parents=True, exist_ok=True)
+        save_gdrive_config(root=str(self.gdrive_base), subfolder=self.subfolder)
+        click.echo(f"Configured: {self.dest_root}")
+
+    def backup_file(self, source: Path, dest_relative: str) -> None:
+        dest = self.dest_root / dest_relative
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(source), str(dest))
+
+    def backup_all(self, library_path: Path, *, emit: bool = True) -> int:
+        from wst.document import is_supported
+
+        count = 0
+        for f in sorted(p for p in library_path.rglob("*") if p.is_file() and is_supported(p)):
+            relative = str(f.relative_to(library_path))
+            if emit:
+                click.echo(f"  {relative}... ", nl=False)
+            self.backup_file(f, relative)
+            if emit:
+                click.echo("done")
+            count += 1
+
+        db_path = library_path / "wst.db"
+        if db_path.exists():
+            if emit:
+                click.echo("  wst.db... ", nl=False)
+            self.backup_file(db_path, "wst.db")
+            if emit:
+                click.echo("done")
+
+        return count
+
+
 PROVIDERS: dict[str, type[BackupProvider]] = {
     "icloud": ICloudProvider,
+    "gdrive": GoogleDriveProvider,
     "s3": S3Provider,
 }
 
@@ -326,6 +476,8 @@ def run_backup_interactive(
     library_path: Path,
 ) -> None:
     """Interactive backup flow: choose all or select a file."""
+    from InquirerPy import inquirer
+
     if not provider.is_configured():
         click.echo(f"Provider '{provider.name}' is not configured.")
         provider.configure()

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -440,23 +440,77 @@ def backup(ctx: click.Context) -> None:
 @backup.command("icloud")
 @command_format_option()
 @click.argument("identifier", required=False, default=None)
+@click.option("--all", "all_files", is_flag=True, help="Back up the whole library.")
+@click.option("--configure", is_flag=True, help="Confirm/save iCloud configuration.")
+@click.option("--subfolder", default=None, help="Subfolder name under iCloud Drive.")
 @click.pass_context
-def backup_icloud(ctx: click.Context, identifier: str | None) -> None:
+def backup_icloud(
+    ctx: click.Context,
+    identifier: str | None,
+    all_files: bool,
+    configure: bool,
+    subfolder: str | None,
+) -> None:
     """Backup files to iCloud Drive."""
-    from wst.backup import ICloudProvider, run_backup_file, run_backup_interactive
+    from wst.backup import (
+        ICloudProvider,
+        run_backup_all,
+        run_backup_file,
+        run_backup_interactive,
+    )
 
     config: WstConfig = ctx.obj["config"]
     fmt: str = ctx.obj.get("format", "human")
-    provider = ICloudProvider()
+    provider = ICloudProvider(subfolder=subfolder) if subfolder else ICloudProvider()
     db = Database(config.db_path)
 
+    if configure and (subfolder is not None or fmt != "human"):
+        # Non-interactive configure path — used by GUI inline wizard.
+        from wst.output import WstError, render_ok
+
+        if not provider.icloud_base or not provider.icloud_base.exists():
+            raise WstError(
+                "config_error",
+                "iCloud Drive is not available on this system.",
+                exit_code=2,
+            )
+        provider.dest_root = provider.icloud_base / (subfolder or "wst")
+        provider.dest_root.mkdir(parents=True, exist_ok=True)
+        result = {"provider": "icloud", "configured": True, "root": str(provider.dest_root)}
+        if fmt == "human":
+            click.echo(f"Configured: {provider.dest_root}")
+        else:
+            render_ok(result, fmt=fmt)
+        return
+
+    if configure:
+        provider.configure()
+        return
+
     try:
+        if all_files:
+            if not provider.is_configured():
+                from wst.output import WstError
+
+                raise WstError(
+                    "requires_interactive",
+                    "Backup provider is not configured.",
+                    details={"hint": "Try: wst backup icloud --format human"},
+                    exit_code=2,
+                )
+            result = run_backup_all(provider, config.library_path, emit=(fmt == "human"))
+            if fmt != "human":
+                from wst.output import render_ok
+
+                render_ok(result, fmt=fmt)
+            return
+
         if fmt != "human" and not identifier:
             from wst.output import WstError
 
             raise WstError(
                 "usage_error",
-                "Non-interactive backup requires an IDENTIFIER (ID or exact title).",
+                "Non-interactive backup requires an IDENTIFIER (ID or exact title) or --all.",
                 details={"hint": "Try: wst backup icloud 3 --format json"},
                 exit_code=2,
             )
@@ -485,15 +539,175 @@ def backup_icloud(ctx: click.Context, identifier: str | None) -> None:
         db.close()
 
 
+@backup.command("gdrive")
+@command_format_option()
+@click.argument("identifier", required=False, default=None)
+@click.option(
+    "--path",
+    "explicit_path",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help="Explicit path to your Google Drive root (overrides auto-detection).",
+)
+@click.option("--configure", is_flag=True, help="Run interactive configuration")
+@click.option("--subfolder", default=None, help="Subfolder name under Google Drive.")
+@click.option("--all", "all_files", is_flag=True, help="Back up the whole library.")
+@click.pass_context
+def backup_gdrive(
+    ctx: click.Context,
+    identifier: str | None,
+    explicit_path: Path | None,
+    configure: bool,
+    subfolder: str | None,
+    all_files: bool,
+) -> None:
+    """Backup files to Google Drive (sync folder).
+
+    \b
+    Uses your local Google Drive for Desktop sync folder. On macOS, multiple
+    accounts result in multiple ~/Library/CloudStorage/GoogleDrive-* entries;
+    by default the first match is auto-picked. Pass --path to override.
+
+    \b
+    Examples:
+        wst backup gdrive --configure              # interactive setup
+        wst backup gdrive                           # interactive backup
+        wst backup gdrive 3                         # backup document by ID
+        wst backup gdrive --path "/Volumes/Drive"   # explicit Drive root
+    """
+    from wst.backup import (
+        GoogleDriveProvider,
+        run_backup_all,
+        run_backup_file,
+        run_backup_interactive,
+    )
+
+    config: WstConfig = ctx.obj["config"]
+    fmt: str = ctx.obj.get("format", "human")
+
+    if explicit_path or (configure and subfolder is not None):
+        provider = GoogleDriveProvider(
+            subfolder=subfolder or "wst",
+            root=explicit_path,
+        )
+    else:
+        provider = GoogleDriveProvider()
+
+    if configure and (explicit_path or subfolder is not None or fmt != "human"):
+        # Non-interactive configure path — used by GUI inline wizard.
+        from wst.config import save_gdrive_config
+        from wst.output import WstError, render_ok
+
+        if not provider.gdrive_base or not provider.gdrive_base.exists():
+            raise WstError(
+                "config_error",
+                "Google Drive sync folder not found. Pass --path to specify it explicitly.",
+                exit_code=2,
+            )
+        provider.dest_root = provider.gdrive_base / provider.subfolder
+        provider.dest_root.mkdir(parents=True, exist_ok=True)
+        save_gdrive_config(root=str(provider.gdrive_base), subfolder=provider.subfolder)
+        result = {"provider": "gdrive", "configured": True, "root": str(provider.dest_root)}
+        if fmt == "human":
+            click.echo(f"Configured: {provider.dest_root}")
+        else:
+            render_ok(result, fmt=fmt)
+        return
+
+    if configure:
+        provider.configure()
+        return
+
+    db = Database(config.db_path)
+    try:
+        if all_files:
+            if not provider.is_configured():
+                from wst.output import WstError
+
+                raise WstError(
+                    "requires_interactive",
+                    "Backup provider is not configured.",
+                    details={"hint": "Try: wst backup gdrive --configure --format human"},
+                    exit_code=2,
+                )
+            result = run_backup_all(provider, config.library_path, emit=(fmt == "human"))
+            if fmt != "human":
+                from wst.output import render_ok
+
+                render_ok(result, fmt=fmt)
+            return
+
+        if fmt != "human" and not identifier:
+            from wst.output import WstError
+
+            raise WstError(
+                "usage_error",
+                "Non-interactive backup requires an IDENTIFIER (ID or exact title) or --all.",
+                details={"hint": "Try: wst backup gdrive 3 --format json"},
+                exit_code=2,
+            )
+
+        if identifier:
+            if fmt == "human":
+                run_backup_file(provider, db, config.library_path, identifier, emit=True)
+                return
+            if not provider.is_configured():
+                from wst.output import WstError
+
+                raise WstError(
+                    "requires_interactive",
+                    "Backup provider is not configured. "
+                    "Run `wst backup gdrive --configure` in human mode first.",
+                    details={"hint": "Try: wst backup gdrive --configure --format human"},
+                    exit_code=2,
+                )
+            run_backup_file(provider, db, config.library_path, identifier, emit=False)
+            from wst.output import render_ok
+
+            render_ok({"provider": "gdrive", "identifier": identifier, "status": "ok"}, fmt=fmt)
+        else:
+            run_backup_interactive(provider, db, config.library_path)
+    finally:
+        db.close()
+
+
+@backup.command("providers")
+@command_format_option()
+@click.pass_context
+def backup_providers(ctx: click.Context) -> None:
+    """List available backup providers and their configured state."""
+    from wst.backup import PROVIDERS
+    from wst.output import render_ok
+
+    fmt: str = ctx.obj.get("format", "human")
+    rows = []
+    for name, cls in PROVIDERS.items():
+        try:
+            instance = cls()
+            configured = bool(instance.is_configured())
+        except Exception:
+            configured = False
+        rows.append({"name": name, "configured": configured})
+
+    if fmt == "human":
+        for row in rows:
+            mark = "✓" if row["configured"] else "✗"
+            click.echo(f"  {mark} {row['name']}")
+    else:
+        render_ok({"providers": rows}, fmt=fmt)
+
+
 @backup.command("s3")
 @command_format_option()
 @click.argument("identifier", required=False, default=None)
 @click.option("--configure", is_flag=True, help="Configure S3 credentials")
+@click.option("--all", "all_files", is_flag=True, help="Back up the whole library.")
 @click.pass_context
 def backup_s3(
     ctx: click.Context,
     identifier: str | None,
     configure: bool,
+    all_files: bool,
 ) -> None:
     """Backup files to S3 (or S3-compatible storage).
 
@@ -508,7 +722,12 @@ def backup_s3(
         wst backup s3 3                  # backup document by ID
         wst backup s3 "Cosmos"           # backup document by title
     """
-    from wst.backup import S3Provider, run_backup_file, run_backup_interactive
+    from wst.backup import (
+        S3Provider,
+        run_backup_all,
+        run_backup_file,
+        run_backup_interactive,
+    )
 
     config: WstConfig = ctx.obj["config"]
     fmt: str = ctx.obj.get("format", "human")
@@ -529,12 +748,29 @@ def backup_s3(
 
     db = Database(config.db_path)
     try:
+        if all_files:
+            if not provider.is_configured():
+                from wst.output import WstError
+
+                raise WstError(
+                    "requires_interactive",
+                    "Backup provider is not configured.",
+                    details={"hint": "Try: wst backup s3 --configure --format human"},
+                    exit_code=2,
+                )
+            result = run_backup_all(provider, config.library_path, emit=(fmt == "human"))
+            if fmt != "human":
+                from wst.output import render_ok
+
+                render_ok(result, fmt=fmt)
+            return
+
         if fmt != "human" and not identifier:
             from wst.output import WstError
 
             raise WstError(
                 "usage_error",
-                "Non-interactive backup requires an IDENTIFIER (ID or exact title).",
+                "Non-interactive backup requires an IDENTIFIER (ID or exact title) or --all.",
                 details={"hint": "Try: wst backup s3 3 --format json"},
                 exit_code=2,
             )

--- a/src/wst/config.py
+++ b/src/wst/config.py
@@ -54,6 +54,22 @@ def save_s3_config(
     _save_config_file(data)
 
 
+def get_gdrive_config() -> dict | None:
+    """Get Google Drive configuration from config.json. Returns None if not configured."""
+    data = _load_config_file()
+    gdrive = data.get("gdrive")
+    if not gdrive or not gdrive.get("root"):
+        return None
+    return gdrive
+
+
+def save_gdrive_config(root: str, subfolder: str = "wst") -> None:
+    """Save Google Drive configuration to config.json."""
+    data = _load_config_file()
+    data["gdrive"] = {"root": root, "subfolder": subfolder}
+    _save_config_file(data)
+
+
 @dataclass
 class WstConfig:
     home_path: Path = field(default_factory=lambda: WST_HOME)

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,12 +1,23 @@
+from unittest.mock import patch
+
 import pytest
 
-from wst.backup import ICloudProvider, get_provider
+from wst.backup import (
+    GoogleDriveProvider,
+    ICloudProvider,
+    _detect_gdrive_bases,
+    get_provider,
+)
 
 
 class TestGetProvider:
     def test_returns_icloud(self):
         provider = get_provider("icloud")
         assert isinstance(provider, ICloudProvider)
+
+    def test_returns_gdrive(self):
+        provider = get_provider("gdrive")
+        assert isinstance(provider, GoogleDriveProvider)
 
     def test_unknown_raises(self):
         with pytest.raises(ValueError, match="Unknown backup provider"):
@@ -76,3 +87,89 @@ class TestICloudProvider:
 
         dest = provider.dest_root / "books" / "test.pdf"
         assert dest.read_text() == "v2"
+
+
+class TestGoogleDriveProvider:
+    def test_explicit_root_skips_detection(self, tmp_path):
+        drive = tmp_path / "DriveRoot"
+        drive.mkdir()
+        provider = GoogleDriveProvider(root=drive)
+
+        assert provider.is_configured()
+        assert provider.gdrive_base == drive
+        assert provider.dest_root == drive / "wst"
+
+    def test_unconfigured_when_no_drive_present(self, tmp_path):
+        with (
+            patch("wst.backup._detect_gdrive_bases", return_value=[]),
+            patch("wst.backup.get_gdrive_config", return_value=None, create=True),
+        ):
+            provider = GoogleDriveProvider()
+            assert not provider.is_configured()
+
+    def test_backup_file(self, tmp_path):
+        provider = GoogleDriveProvider(root=tmp_path / "DriveRoot")
+        source = tmp_path / "test.pdf"
+        source.write_text("content")
+
+        provider.backup_file(source, "books/test.pdf")
+        dest = provider.dest_root / "books" / "test.pdf"
+        assert dest.exists()
+        assert dest.read_text() == "content"
+
+    def test_backup_all(self, tmp_path):
+        provider = GoogleDriveProvider(root=tmp_path / "DriveRoot")
+
+        library = tmp_path / "library"
+        (library / "books").mkdir(parents=True)
+        (library / "books" / "a.pdf").write_text("a")
+        (library / "wst.db").write_text("db")
+
+        count = provider.backup_all(library, emit=False)
+        assert count == 1
+        assert (provider.dest_root / "books" / "a.pdf").exists()
+        assert (provider.dest_root / "wst.db").exists()
+
+
+class TestDetectGdriveBases:
+    def test_picks_modern_macos_drive(self, tmp_path, monkeypatch):
+        fake_home = tmp_path
+        cs = fake_home / "Library" / "CloudStorage" / "GoogleDrive-user@example.com" / "My Drive"
+        cs.mkdir(parents=True)
+        monkeypatch.setattr("wst.backup.Path.home", lambda: fake_home)
+        monkeypatch.setattr("wst.backup.platform.system", lambda: "Darwin")
+
+        bases = _detect_gdrive_bases()
+        assert cs in bases
+
+    def test_returns_multiple_macos_accounts_sorted(self, tmp_path, monkeypatch):
+        fake_home = tmp_path
+        for email in ("z@example.com", "a@example.com"):
+            (fake_home / "Library" / "CloudStorage" / f"GoogleDrive-{email}" / "My Drive").mkdir(
+                parents=True
+            )
+        monkeypatch.setattr("wst.backup.Path.home", lambda: fake_home)
+        monkeypatch.setattr("wst.backup.platform.system", lambda: "Darwin")
+
+        bases = _detect_gdrive_bases()
+        # GoogleDrive-a@... sorts before GoogleDrive-z@...
+        assert len(bases) >= 2
+        assert "GoogleDrive-a" in str(bases[0])
+
+    def test_empty_when_no_drive(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("wst.backup.Path.home", lambda: tmp_path)
+        monkeypatch.setattr("wst.backup.platform.system", lambda: "Darwin")
+        assert _detect_gdrive_bases() == []
+
+
+class TestGdriveConfig:
+    def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "wst"
+        monkeypatch.setattr("wst.config.WST_HOME", fake_home)
+        monkeypatch.setattr("wst.config.CONFIG_FILE", fake_home / "config.json")
+
+        from wst.config import get_gdrive_config, save_gdrive_config
+
+        save_gdrive_config(root="/tmp/MyDrive", subfolder="books")
+        cfg = get_gdrive_config()
+        assert cfg == {"root": "/tmp/MyDrive", "subfolder": "books"}


### PR DESCRIPTION
Closes #35

This PR contains RFC 0014 proposing to add a `GoogleDriveProvider` (sync-folder backup, mirroring `ICloudProvider`) and to expand the GUI so users can pick a provider and run "Backup all" without dropping to the CLI.

**The problem**: today the CLI supports backup to iCloud and S3 (full library or single file), but the GUI only does single-file iCloud backup. Google Drive isn't supported anywhere.

**The proposal**: filesystem-sync `gdrive` provider parallel to iCloud (no Google Drive API/OAuth), three new Tauri commands (`backup_document`, `backup_all`, `list_backup_providers`), and a small UI surface in `BookDetail` and a new "Backup all" entry point.

## What's in this PR (RFC phase)

- `docs/rfcs/0014-backup-all-cloud-providers.md` — full design with provider behavior, CLI/GUI changes, alternatives, and open questions.

## Open questions

Five questions in the RFC (Q1–Q5) — multi-account macOS Drive detection, where "Backup all" lives in the GUI, subfolder default, behavior when no provider is configured, and Tauri command renaming.

**To approve:** add the `approved` label to issue #35.
**To request changes:** leave a comment on this PR or the issue.