### PR TITLE
RFC: Cache Rust/npm/pip in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install -e ".[dev]"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
@@ -37,6 +39,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install build
       - run: python -m build
       - name: Publish to PyPI
@@ -59,12 +63,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri -> target
 
       - name: Build standalone wst CLI binary
         run: |
@@ -117,12 +129,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri -> target
 
       - name: Build standalone wst CLI binary
         shell: pwsh
@@ -191,12 +211,20 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: app/src-tauri -> target
 
       - name: Build standalone wst CLI binary
         run: |

--- a/docs/rfcs/0015-ci-release-caches.md
+++ b/docs/rfcs/0015-ci-release-caches.md
@@ -1,7 +1,7 @@
 # RFC 0015: Cache Rust/npm/pip in the release workflow
 
 **Issue**: #37
-**Status**: Draft — awaiting approval
+**Status**: Implementing
 **Branch**: `rfc/37-ci-release-caches`
 
 ---

--- a/docs/rfcs/0015-ci-release-caches.md
+++ b/docs/rfcs/0015-ci-release-caches.md
@@ -1,0 +1,70 @@
+# RFC 0015: Cache Rust/npm/pip in the release workflow
+
+**Issue**: #37
+**Status**: Draft — awaiting approval
+**Branch**: `rfc/37-ci-release-caches`
+
+---
+
+## Problem
+
+`release.yml` runs three platform jobs in parallel (`dmg`, `windows-installer`, `linux`), called via `workflow_call` from `release-on-tag.yml`. Each job recompiles **everything** from scratch:
+
+- Tauri's Rust crate under `app/src-tauri/target/`
+- The frontend's `app/node_modules/`
+- Python deps for the bundled CLI (`pip install -e . numpy scikit-learn scipy pyinstaller`)
+
+`grep "actions/cache\|rust-cache\|cache:" .github/workflows/release.yml` returns nothing — there is no caching anywhere in the workflow today. Every release pays the full cold-build cost on three runners.
+
+This is the largest avoidable cost in the release pipeline. The three jobs already run in parallel, so wall-clock time is bounded by the slowest job (typically macOS DMG). Cache hits should reduce the slow path noticeably.
+
+---
+
+## Proposed Solution
+
+Add three caches to each platform job in `release.yml`. None of the runners share caches with each other — GitHub keys cache by OS automatically — so the change is purely additive per job.
+
+### What gets cached
+
+| Cache | Action | Scope |
+|---|---|---|
+| Rust target dir + registry | `Swatinem/rust-cache@v2` (with `workspaces: app/src-tauri -> target`) | Per-OS, keyed on `Cargo.lock` |
+| npm dependencies | `actions/setup-node@v4` with `cache: npm` and `cache-dependency-path: app/package-lock.json` | Per-OS, keyed on lockfile |
+| pip dependencies | `actions/setup-python@v5` with `cache: pip` | Per-OS, keyed on `pyproject.toml` |
+
+### Where the steps go in each job
+
+The new caches replace the existing `setup-node` / `setup-python` steps (which currently don't enable `cache:`) and add a `Swatinem/rust-cache@v2` step *before* `tauri build`. PyInstaller numerical deps (numpy/scipy/scikit-learn) are heavy wheels; pip cache should hit on those even when our own code changes.
+
+### Expected impact
+
+- **Cold build** (no cache, e.g. first run after lockfile change): unchanged.
+- **Warm build** (typical release on `main`): -5 to -10 min on macOS, less on Linux/Windows but still meaningful. Hard to be precise without measuring; we'll know after the first warm run.
+- **Storage**: GitHub gives 10 GB per repo, evicted LRU. Three caches × three OSes ≈ a few GB. Within budget.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| `sccache` (compile cache for Rust) | Stronger but more setup (bucket or local config). Try `Swatinem/rust-cache` first; revisit if it's not enough. |
+| Skip PyInstaller rebuild when `pyproject.toml` is unchanged | Plausible but PyInstaller's outputs depend on the full Python env, not just the lockfile. pip cache is the safer lever. |
+| Cache the macOS universal target | Out of scope — we don't ship universal binaries today. |
+| Move to a single self-hosted runner with persistent state | Operational overhead, not worth it for this project's release cadence. |
+
+---
+
+## Open Questions
+
+None — the issue body and the actions involved are well-known. Ready for approval.
+
+---
+
+## Implementation Plan
+
+- [ ] In `release.yml`, replace the existing `setup-node` step in each platform job with one that enables `cache: npm` and `cache-dependency-path: app/package-lock.json`.
+- [ ] In each platform job, add `actions/setup-python@v5` with `cache: pip` (or update the existing Python setup if there is one).
+- [ ] In each platform job, add `Swatinem/rust-cache@v2` with `workspaces: app/src-tauri -> target` *before* the `npx tauri build` step.
+- [ ] Trigger a no-op release (or rely on the next regular release) to populate caches, then a follow-up release to confirm warm-cache speedup.
+- [ ] Note the timing in the PR description so we have a baseline for future tuning.


### PR DESCRIPTION
Closes #37

This PR contains RFC 0015 proposing to add `Swatinem/rust-cache`, npm cache, and pip cache to the three platform jobs in `release.yml`.

**The problem**: today `release.yml` has zero caching — every release recompiles Tauri's Rust crate, reinstalls npm deps, and reinstalls heavy pip deps (numpy/scipy/scikit-learn) on three runners.

**The proposal**: three additive cache steps per platform job. Cold builds unchanged; warm builds should drop 5–10 min on the slow path (macOS).

## What's in this PR (RFC phase)

- `docs/rfcs/0015-ci-release-caches.md` — short RFC with the cache stack, expected impact, and implementation plan.

## Open questions

None — the design space is small. Ready for approval.

**To approve:** add the `approved` label to issue #37.
**To request changes:** comment on this PR or the issue.