### PR TITLE
RFC: OCR and topic modeling from the GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ wst backup providers --format json  # list providers and configured state
 | `wst fix` | Batch enrich documents with missing metadata. Options: `--type`, `--field`, `--dry-run`, `-y` |
 | `wst stats` | Show metadata coverage statistics. Options: `--type` |
 | `wst browse` | Interactive TUI for browsing and editing documents |
-| `wst ocr <id-or-path>` | Run OCR on scanned PDFs |
+| `wst ocr <id-or-title-or-path>` | Run OCR on scanned PDFs. Accepts a document ID, title, or filesystem path. Also exposed in the GUI as an OCR button on each document. |
 | `wst backup [provider]` | Backup files to iCloud, Google Drive, or S3. Providers: `icloud`, `gdrive`, `s3`. Use `--all` for full-library backup. The GUI exposes the same providers via the **Backup pane** in the sidebar. |
-| `wst topics build` | Cluster the corpus into a topic vocabulary and assign topics to every document |
+| `wst topics build` | Cluster the corpus into a topic vocabulary and assign topics to every document. Also exposed in the GUI as a **Topics pane** in the sidebar with progress streaming. |
 
 ## How Ingestion Works
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -279,6 +279,109 @@ pub fn cancel_ingest(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// RFC 0016 — topics build from GUI (streaming via NDJSON)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize, Default)]
+pub struct TopicsBuildOpts {
+    /// Optional --n-topics override; None means auto-detect.
+    pub n_topics: Option<u32>,
+}
+
+#[derive(serde::Serialize, Default)]
+pub struct TopicsBuildResult {
+    pub vocabulary: Vec<String>,
+    pub assigned_count: u64,
+    pub subjects_updated: u64,
+}
+
+#[tauri::command]
+pub async fn build_topics(
+    opts: Option<TopicsBuildOpts>,
+    window: Window,
+) -> Result<TopicsBuildResult, String> {
+    let opts = opts.unwrap_or_default();
+    let wst_path = which_wst();
+
+    let mut args: Vec<String> = vec![
+        "topics".into(),
+        "build".into(),
+        "--yes".into(),
+        "--format".into(),
+        "ndjson".into(),
+    ];
+    if let Some(n) = opts.n_topics {
+        args.push("--n-topics".into());
+        args.push(n.to_string());
+    }
+
+    let mut child = Command::new(&wst_path)
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn wst: {e}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "missing stdout from wst".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "missing stderr from wst".to_string())?;
+
+    let win_err = window.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = win_err.emit("topics:log", line);
+        }
+    });
+
+    let win = window.clone();
+    let parse_handle = tauri::async_runtime::spawn_blocking(
+        move || -> Result<TopicsBuildResult, String> {
+            let reader = BufReader::new(stdout);
+            let mut result = TopicsBuildResult::default();
+            for line in reader.lines().map_while(Result::ok) {
+                let value: serde_json::Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let _ = win.emit("topics:event", value.clone());
+                if value.get("event").and_then(|v| v.as_str()) == Some("done") {
+                    result.vocabulary = value
+                        .get("vocabulary")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    result.assigned_count = value
+                        .get("assigned_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    result.subjects_updated = value
+                        .get("subjects_updated")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                }
+            }
+            Ok(result)
+        },
+    );
+
+    let result = parse_handle
+        .await
+        .map_err(|e| format!("parse task failed: {e}"))??;
+    let _ = child.wait();
+    Ok(result)
+}
+
 #[tauri::command]
 pub fn backup_to_icloud(library_path: State<LibraryPath>) -> Result<String, String> {
     let home = dirs::home_dir().ok_or("Could not determine home directory")?;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
             commands::backup_to_icloud,
             commands::ingest_files,
             commands::cancel_ingest,
+            commands::build_topics,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Wan Shi Tong");

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,17 +7,9 @@ import {
   activeSubject,
   sortBy,
   viewMode,
-  setLibraryStats,
-  setAllTopicsVocab,
-  setAllSubjects,
+  refreshLibraryState,
 } from "./lib/store";
-import {
-  listDocuments,
-  searchDocuments,
-  getLibraryStats,
-  getTopicsVocabulary,
-  getSubjects,
-} from "./lib/tauri";
+import { listDocuments, searchDocuments } from "./lib/tauri";
 import SearchBar from "./components/SearchBar";
 import Sidebar from "./components/Sidebar";
 import Toolbar, {
@@ -37,18 +29,7 @@ export default function App() {
   let fetchId = 0;
   const [fading, setFading] = createSignal(false);
 
-  onMount(async () => {
-    const [stats, docs, vocab, subjects] = await Promise.all([
-      getLibraryStats(),
-      listDocuments(),
-      getTopicsVocabulary(),
-      getSubjects(),
-    ]);
-    setLibraryStats(stats);
-    setDocuments(docs);
-    setAllTopicsVocab(vocab);
-    setAllSubjects(subjects);
-  });
+  onMount(refreshLibraryState);
 
   createEffect(
     on(
@@ -119,19 +100,7 @@ export default function App() {
       <Show when={showIngest()}>
         <IngestModal
           onClose={() => setShowIngest(false)}
-          onComplete={async () => {
-            // RFC 0013 — refresh library state after a GUI ingest run.
-            const [stats, docs, vocab, subjects] = await Promise.all([
-              getLibraryStats(),
-              listDocuments(),
-              getTopicsVocabulary(),
-              getSubjects(),
-            ]);
-            setLibraryStats(stats);
-            setDocuments(docs);
-            setAllTopicsVocab(vocab);
-            setAllSubjects(subjects);
-          }}
+          onComplete={refreshLibraryState}
         />
       </Show>
     </div>

--- a/app/src/components/BookDetail.tsx
+++ b/app/src/components/BookDetail.tsx
@@ -8,8 +8,10 @@ import {
   getTopicsVocabulary,
   backupDocument,
   listBackupProviders,
+  ocrDocument,
   type BackupProvider,
 } from "../lib/tauri";
+import { refreshLibraryState } from "../lib/store";
 import { DOC_TYPE_LABELS } from "../lib/types";
 import type { Document } from "../lib/types";
 
@@ -133,6 +135,32 @@ export default function BookDetail() {
     }
   };
 
+  const [ocrRunning, setOcrRunning] = createSignal(false);
+
+  const handleOcr = async (id: number) => {
+    if (ocrRunning()) return;
+    setOcrRunning(true);
+    setBackupError(false);
+    setBackupStatus("Ejecutando OCR…");
+    try {
+      const result = await ocrDocument(id);
+      const summary =
+        result.ok_count > 0
+          ? "OCR completado ✓"
+          : result.skipped_count > 0
+            ? "Ya tenía texto, OCR omitido"
+            : "OCR sin cambios";
+      setBackupStatus(summary);
+      await refreshLibraryState();
+    } catch (err) {
+      setBackupError(true);
+      setBackupStatus(String(err));
+    } finally {
+      setOcrRunning(false);
+      setTimeout(() => setBackupStatus(null), 4000);
+    }
+  };
+
   const close = () => {
     setEditing(false);
     setSelectedDoc(null);
@@ -179,6 +207,14 @@ export default function BookDetail() {
                     onClick={() => revealInFinder(d().file_path)}
                   >
                     Mostrar en Finder
+                  </button>
+                  <button
+                    class="btn btn-secondary"
+                    onClick={() => handleOcr(d().id)}
+                    disabled={ocrRunning()}
+                    title="Ejecuta OCR si el PDF es escaneado (skip si ya tiene texto)"
+                  >
+                    {ocrRunning() ? "OCR…" : "🔍 OCR"}
                   </button>
                   <div class="backup-menu">
                     <button

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/store";
 import { DOC_TYPE_LABELS } from "../lib/types";
 import BackupPane from "./BackupPane";
+import TopicsPane from "./TopicsPane";
 
 const STORAGE_KEY = "wst.sidebarWidth";
 const MIN_WIDTH = 160;
@@ -156,6 +157,7 @@ export default function Sidebar() {
       </Show>
 
       <BackupPane />
+      <TopicsPane />
 
       <div class="sidebar-resize-handle" onMouseDown={onHandleMouseDown} />
     </nav>

--- a/app/src/components/TopicsPane.tsx
+++ b/app/src/components/TopicsPane.tsx
@@ -1,0 +1,182 @@
+import { Show, createSignal, onCleanup } from "solid-js";
+import {
+  buildTopics,
+  onTopicsEvent,
+  type TopicsEvent,
+} from "../lib/tauri";
+import { allTopicsVocab, refreshLibraryState } from "../lib/store";
+
+type Phase =
+  | "idle"
+  | "confirm"
+  | "running"
+  | "done"
+  | "error";
+
+export default function TopicsPane() {
+  const [phase, setPhase] = createSignal<Phase>("idle");
+  const [error, setError] = createSignal<string | null>(null);
+  const [statusLine, setStatusLine] = createSignal<string>("");
+  const [progress, setProgress] = createSignal<{ index: number; total: number } | null>(null);
+  const [showAdvanced, setShowAdvanced] = createSignal(false);
+  const [nTopicsInput, setNTopicsInput] = createSignal("");
+
+  const startBuild = async () => {
+    setPhase("running");
+    setError(null);
+    setStatusLine("Iniciando…");
+    setProgress(null);
+
+    const unlisten = await onTopicsEvent((event: TopicsEvent) => {
+      switch (event.event) {
+        case "phase":
+          setStatusLine(phaseLabel(event.name));
+          setProgress(null);
+          break;
+        case "doc":
+          setStatusLine(`Asignando ${event.index}/${event.total}…`);
+          setProgress({ index: event.index, total: event.total });
+          break;
+        case "done":
+          setStatusLine(
+            `Listo: ${event.vocabulary.length} temas, ${event.assigned_count} documentos.`
+          );
+          break;
+      }
+    });
+
+    try {
+      const parsed = parseInt(nTopicsInput(), 10);
+      const opts = Number.isFinite(parsed) && parsed > 0 ? { nTopics: parsed } : {};
+      await buildTopics(opts);
+      await refreshLibraryState();
+      setPhase("done");
+    } catch (err) {
+      setError(String(err));
+      setPhase("error");
+    } finally {
+      unlisten();
+    }
+  };
+
+  const reset = () => {
+    setPhase("idle");
+    setError(null);
+    setStatusLine("");
+    setProgress(null);
+    setNTopicsInput("");
+    setShowAdvanced(false);
+  };
+
+  onCleanup(() => {
+    // any in-flight listener is cleaned in startBuild's finally
+  });
+
+  return (
+    <div class="topics-pane">
+      <div class="sidebar-section-label sidebar-section-sep">
+        Temas (Topic modeling)
+      </div>
+      <div class="topics-pane-body">
+        <Show when={allTopicsVocab().length > 0}>
+          <p class="topics-pane-hint">
+            Vocabulario actual: {allTopicsVocab().length} temas.
+          </p>
+        </Show>
+        <button
+          class="btn btn-primary btn-small"
+          disabled={phase() === "running"}
+          onClick={() => setPhase("confirm")}
+        >
+          {phase() === "running" ? "Reconstruyendo…" : "Reconstruir vocabulario"}
+        </button>
+      </div>
+
+      <Show when={phase() === "confirm"}>
+        <div class="topics-confirm">
+          <p>
+            Esto recomputa los temas para toda la biblioteca. Puede tardar unos minutos.
+          </p>
+          <div class="topics-confirm-advanced">
+            <button
+              type="button"
+              class="topics-link"
+              onClick={() => setShowAdvanced(!showAdvanced())}
+            >
+              {showAdvanced() ? "Ocultar avanzado" : "Mostrar avanzado"}
+            </button>
+            <Show when={showAdvanced()}>
+              <label class="topics-confirm-field">
+                <span>Número de temas (vacío = auto-detect)</span>
+                <input
+                  type="number"
+                  min="2"
+                  max="50"
+                  value={nTopicsInput()}
+                  onInput={(e) => setNTopicsInput(e.currentTarget.value)}
+                  placeholder="auto"
+                />
+              </label>
+            </Show>
+          </div>
+          <div class="topics-confirm-actions">
+            <button class="btn btn-primary btn-small" onClick={startBuild}>
+              Reconstruir
+            </button>
+            <button class="btn btn-secondary btn-small" onClick={reset}>
+              Cancelar
+            </button>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={phase() === "running"}>
+        <div class="topics-progress">
+          <p class="topics-progress-line">{statusLine()}</p>
+          <Show when={progress()}>
+            <progress
+              max={progress()!.total}
+              value={progress()!.index}
+              class="topics-progress-bar"
+            />
+          </Show>
+        </div>
+      </Show>
+
+      <Show when={phase() === "done"}>
+        <div class="topics-done">
+          <p>{statusLine()}</p>
+          <button class="btn btn-secondary btn-small" onClick={reset}>
+            Cerrar
+          </button>
+        </div>
+      </Show>
+
+      <Show when={phase() === "error"}>
+        <div class="topics-error">
+          <p>{error()}</p>
+          <button class="btn btn-secondary btn-small" onClick={reset}>
+            Cerrar
+          </button>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+function phaseLabel(name: string): string {
+  switch (name) {
+    case "backfill_previews":
+      return "Generando previews de contenido…";
+    case "embedding":
+      return "Embeddings y clustering…";
+    case "assigning":
+      return "Asignando temas…";
+    case "saving":
+      return "Guardando vocabulario…";
+    case "subjects":
+      return "Backfill de subjects…";
+    default:
+      return name;
+  }
+}

--- a/app/src/lib/store.ts
+++ b/app/src/lib/store.ts
@@ -1,5 +1,11 @@
 import { createSignal } from "solid-js";
 import type { Document, LibraryStats } from "./types";
+import {
+  getLibraryStats,
+  getSubjects,
+  getTopicsVocabulary,
+  listDocuments,
+} from "./tauri";
 
 export const [documents, setDocuments] = createSignal<Document[]>([]);
 export const [searchQuery, setSearchQuery] = createSignal("");
@@ -25,4 +31,22 @@ export function clearAllFilters() {
   setActiveDocType(null);
   setActiveTopic(null);
   setActiveSubject(null);
+}
+
+/**
+ * Re-fetch documents, stats, topic vocab, and subjects from the backend.
+ * Call this after operations that mutate the library: ingest (RFC 0013),
+ * OCR or topics build (RFC 0016).
+ */
+export async function refreshLibraryState(): Promise<void> {
+  const [stats, docs, vocab, subjects] = await Promise.all([
+    getLibraryStats(),
+    listDocuments(),
+    getTopicsVocabulary(),
+    getSubjects(),
+  ]);
+  setLibraryStats(stats);
+  setDocuments(docs);
+  setAllTopicsVocab(vocab);
+  setAllSubjects(subjects);
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -192,3 +192,57 @@ export function onIngestFile(cb: (e: IngestFileEvent) => void) {
 export function onIngestLog(cb: (line: string) => void) {
   return listen<string>("ingest:log", (event) => cb(event.payload));
 }
+
+// ---------------------------------------------------------------------------
+// RFC 0016 — OCR and topics from GUI
+// ---------------------------------------------------------------------------
+
+export interface OcrResult {
+  ok_count: number;
+  skipped_count: number;
+  failed_count: number;
+}
+
+export async function ocrDocument(
+  id: number,
+  opts: { force?: boolean; language?: string } = {}
+): Promise<OcrResult> {
+  const args = ["ocr", String(id), "--format", "json"];
+  if (opts.force) args.push("--force");
+  if (opts.language) args.push("--language", opts.language);
+  const raw = await invoke<string>("run_wst_command", { args });
+  const result = JSON.parse(raw);
+  return result.data as OcrResult;
+}
+
+export type TopicsEvent =
+  | { event: "phase"; name: string; vocabulary?: string[] }
+  | { event: "doc"; index: number; total: number; id: number; topics: string[] }
+  | {
+      event: "done";
+      vocabulary: string[];
+      assigned_count: number;
+      subjects_updated: number;
+    };
+
+export interface TopicsBuildResult {
+  vocabulary: string[];
+  assigned_count: number;
+  subjects_updated: number;
+}
+
+export async function buildTopics(
+  opts: { nTopics?: number } = {}
+): Promise<TopicsBuildResult> {
+  return invoke("build_topics", {
+    opts: { n_topics: opts.nTopics ?? null },
+  });
+}
+
+export function onTopicsEvent(cb: (e: TopicsEvent) => void) {
+  return listen<TopicsEvent>("topics:event", (event) => cb(event.payload));
+}
+
+export function onTopicsLog(cb: (line: string) => void) {
+  return listen<string>("topics:log", (event) => cb(event.payload));
+}

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1210,3 +1210,92 @@ body.resizing {
   gap: 6px;
   justify-content: flex-end;
 }
+
+/* Topics pane in Sidebar (RFC 0016) */
+.topics-pane {
+  margin-top: 12px;
+  padding: 0 8px 8px 8px;
+}
+
+.topics-pane-body {
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.topics-pane-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.topics-confirm,
+.topics-progress,
+.topics-done,
+.topics-error {
+  margin: 8px 8px 0;
+  padding: 10px;
+  background: var(--bg-hover);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.topics-confirm p {
+  margin: 0;
+}
+
+.topics-confirm-advanced {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.topics-link {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0;
+  text-align: left;
+}
+
+.topics-confirm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.topics-confirm-field input {
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topics-confirm-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.topics-progress-line {
+  margin: 0;
+  font-size: 11px;
+}
+
+.topics-progress-bar {
+  width: 100%;
+  height: 6px;
+}
+
+.topics-error {
+  color: #c0392b;
+}

--- a/docs/rfcs/0016-gui-ocr-topics.md
+++ b/docs/rfcs/0016-gui-ocr-topics.md
@@ -1,8 +1,15 @@
 # RFC 0016: OCR and topic modeling from the GUI
 
 **Issue**: #39
-**Status**: Draft — awaiting approval
+**Status**: Implementing
 **Branch**: `rfc/39-gui-ocr-topics`
+
+**Resolutions** (from #39 comments):
+- **Q1**: A — Topics pane lives in the sidebar, below the Backup pane.
+- **Q2**: OCR is one-shot per document (no streaming). Streaming is reserved for topics.
+- **Q3**: Yes, confirmation dialog before topics build. Advanced toggle exposes `--n-topics`.
+- **Q4**: Re-fetch the document list and topic vocabulary after topics build, after ingest, after OCR (and after `wst fix` as a follow-up — fix is out of scope here).
+- **Q5**: A "needs OCR" indicator is welcome **if easy**. We'll evaluate during implementation; if it requires schema migration or a heuristic at ingest, defer to a follow-up.
 
 ---
 

--- a/docs/rfcs/0016-gui-ocr-topics.md
+++ b/docs/rfcs/0016-gui-ocr-topics.md
@@ -1,0 +1,95 @@
+# RFC 0016: OCR and topic modeling from the GUI
+
+**Issue**: #39
+**Status**: Draft — awaiting approval
+**Branch**: `rfc/39-gui-ocr-topics`
+
+---
+
+## Problem
+
+Today the desktop app exposes a small slice of the CLI: list/search/edit/ingest/per-doc iCloud backup, plus the new Backup pane. Two long-running operations are still CLI-only:
+
+- **OCR** (`wst ocr <path>` — [`cli.py:974`](../../src/wst/cli.py)): adds a searchable text layer to scanned PDFs via `ocrmypdf`. Per-document.
+- **Topic modeling** (`wst topics build` — [`cli.py:2110`](../../src/wst/cli.py)): clusters the corpus into a topic vocabulary and assigns topics to every document. Library-wide, multi-minute on a real library.
+
+Users on the GUI today have to drop to a terminal for both, which is the friction this issue calls out.
+
+The pattern for "long-running CLI command, called from the GUI with progress" already exists in **RFC 0013 (ingest from GUI)** — `run_wst_command` spawns the CLI with `--format ndjson`, the Tauri side relays each NDJSON line as a typed event, and the frontend renders progress. We can reuse that pattern almost verbatim.
+
+---
+
+## Proposed Solution
+
+Two new GUI surfaces, each shelling out to its existing CLI command via the established Tauri ingest pattern.
+
+### 1. OCR — per-document button in `BookDetail`
+
+Add a **"OCR"** button next to the existing Edit / Backup buttons in `BookDetail.tsx`. On click:
+
+- The frontend calls a new `tauri.ts` wrapper `ocrDocument(id, opts)` which invokes `run_wst_command` with args `["ocr", "<file_path>", "--format", "ndjson"]`. The current `wst ocr` is human-output-only, so the implementation also adds an `--format ndjson` mode (one event per file with `{event: "file", path, status: "ocrd"|"skipped"|"failed", reason}`) — small extension, parallels `wst ingest --format ndjson`.
+- Status is shown inline like the existing backup status row. Force-OCR is exposed as a small toggle (off by default — auto-detect handles most cases).
+- After success, the row reloads from the DB so the "OCR" indicator (if we add one) reflects new state.
+
+### 2. Topic modeling — entry point in `Sidebar` (next to the Backup pane)
+
+Add a **"Topics"** pane in the sidebar — same visual weight as the Backup pane — with one button: **"Rebuild topic vocabulary"**. On click:
+
+- Confirmation dialog: "This will recompute topics for all N documents and may take a few minutes." (Topics build *replaces* the existing vocabulary — needs an explicit confirm, mirroring the CLI's `-y` prompt.)
+- The frontend calls `tauri.ts` wrapper `buildTopics()` which invokes `run_wst_command` with `["topics", "build", "--yes", "--format", "ndjson"]`.
+- A modal shows progress events streamed over a Tauri channel (mirroring `IngestModal`):
+  - `{event: "phase", name: "embedding"|"clustering"|"naming"|"assigning", message: ...}`
+  - `{event: "doc", id, topics: [...]}` for each per-doc assignment (so the modal can show "Assigning 47/213…")
+  - Final `{event: "done", topics: [...], assigned: N}`
+- On `done`, the frontend re-fetches the topic vocabulary (via the existing `getTopicsVocabulary()`) and the document list, so the sidebar's Topics filter and per-doc chips update.
+
+`wst topics build` is human-output-only today; like OCR, we add an `--format ndjson` mode that emits the events above.
+
+### Tauri / commands surface
+
+No new Rust commands needed. Both new flows go through the existing `run_wst_command`. Two new JS wrappers in `tauri.ts`:
+
+- `ocrDocument(id: number, opts: { force?: boolean }): Promise<OcrResult>`
+- `buildTopics(opts: { nTopics?: number }): Promise<TopicsBuildResult>` — returns the final summary; per-event progress is delivered via a Tauri event listener (`onTopicsEvent` etc.), mirroring `onIngestFile`.
+
+If the streaming progress turns out to be more wiring than it's worth for OCR (which is per-file and usually fast), the OCR path can simplify to a one-shot `run_wst_command` call returning the final `OcrResult` — see Q2 below.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Implement OCR/topics natively in Rust (skip CLI) | Duplicates Python logic (ocrmypdf wrapping, sentence-transformers, KMeans, AI naming). The CLI is the source of truth — wrap it, don't fork it. |
+| Single "Tools" pane with both OCR and topics | Topics is library-wide; OCR is per-document. Different ergonomic homes. |
+| Run topics build automatically after every ingest | Surprising and expensive. Keep it explicit (button-driven). |
+| Batch OCR ("OCR all scanned PDFs") | Useful but bigger scope. The CLI supports `wst ocr <directory>`; we can add this as a follow-up after the per-doc flow lands. |
+| Expose `wst fix` (metadata enrichment) too | Issue title is "OCR + topic modeling". `wst fix` is a separate operation (batch metadata via AI + web search) — out of scope. Could be RFC 0017 if asked. |
+
+---
+
+## Open Questions
+
+> **Q1**: Where exactly should the "Rebuild topics" entry point live? (a) sidebar pane below Backup, (b) inside `ExtrasPanel.tsx` (behaves like a tool/admin action), (c) toolbar button. Lean (a) — sidebar matches the per-feature pane convention we just established with Backup, and topics genuinely is a library-level setting.
+
+> **Q2**: Should OCR stream NDJSON progress, or is it fine as a one-shot call (call returns when done, no per-file events)? Per-doc OCR is usually fast (seconds–tens of seconds per file). One-shot keeps the wiring small. If the user later asks for batch OCR ("OCR all scanned PDFs at once"), we can add streaming then. Lean **one-shot for OCR; streaming for topics**.
+
+> **Q3**: Topics build is destructive (replaces vocabulary, reassigns every doc). Confirmation dialog before kicking it off — yes/no? Lean yes. Should it also offer `--n-topics` as an advanced option, or always auto-detect? Auto-detect is the CLI default; keep advanced hidden behind a "Show advanced" toggle inside the modal.
+
+> **Q4**: When topics build finishes, the GUI needs to refresh: (a) the sidebar's `Temas` list (`getTopicsVocabulary`), (b) every visible document's `topics` chips. Simple approach: re-fetch the document list after `done`. Acceptable, or do we want a finer-grained update? Lean simple re-fetch.
+
+> **Q5**: For OCR, should the GUI show a "needs OCR" indicator on documents detected as scanned? That's a nice-to-have but not in scope here — it would need a new DB column or heuristic at ingest time. Out of scope; flag as a follow-up.
+
+---
+
+## Implementation Plan
+
+- [ ] Add `--format ndjson` to `wst ocr` ([`cli.py:974`](../../src/wst/cli.py)) emitting per-file `{event, path, status, reason}` events. (Out: keep `--format human` and `--format json` working unchanged.)
+- [ ] Add `--format ndjson` to `wst topics build` ([`cli.py:2110`](../../src/wst/cli.py)) emitting `phase` / `doc` / `done` events.
+- [ ] Add `ocrDocument(id, opts)` in `app/src/lib/tauri.ts` — one-shot wrapper around `run_wst_command` (per Q2).
+- [ ] Add `buildTopics(opts)` + `onTopicsEvent(cb)` in `app/src/lib/tauri.ts`, mirroring the ingest pattern.
+- [ ] Add an "OCR" button to `BookDetail.tsx` (next to Edit / Backup), with inline status row.
+- [ ] Add a `TopicsPane.tsx` next to `BackupPane.tsx` in the sidebar, with confirmation dialog and progress modal.
+- [ ] On `topics-build done`, refresh `getTopicsVocabulary()` and re-fetch the document list so chips and filters update.
+- [ ] Smoke-test on the user's library (≥100 docs) end-to-end: OCR a scanned PDF from BookDetail, rebuild topics from the sidebar.
+- [ ] Update `README.md` and the Features section.

--- a/src/wst/cli.py
+++ b/src/wst/cli.py
@@ -1,4 +1,6 @@
+import json
 import shutil
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -948,10 +950,7 @@ def browse(
 
 @cli.command()
 @command_format_option()
-@click.argument(
-    "path",
-    type=click.Path(exists=True, path_type=Path),
-)
+@click.argument("target", type=str)
 @click.option(
     "--language",
     "-l",
@@ -971,8 +970,14 @@ def browse(
     help="Show detailed per-file processing logs",
 )
 @click.pass_context
-def ocr(ctx: click.Context, path: Path, language: str, force: bool, verbose: bool) -> None:
+def ocr(ctx: click.Context, target: str, language: str, force: bool, verbose: bool) -> None:
     """Run OCR on scanned PDFs to make them searchable.
+
+    \b
+    TARGET can be:
+      - a document ID (e.g. 42)
+      - a document title (e.g. "Vector Calculus")
+      - a file path or a directory of PDFs
 
     \b
     Adds an invisible text layer to scanned PDFs using ocrmypdf.
@@ -981,29 +986,72 @@ def ocr(ctx: click.Context, path: Path, language: str, force: bool, verbose: boo
 
     \b
     Examples:
+        wst ocr 42                      # OCR document by ID (used by GUI)
+        wst ocr "Vector Calculus"       # OCR document by title
         wst ocr scan.pdf                # OCR a single file
         wst ocr ~/scans/                # OCR all PDFs in a folder
-        wst ocr scan.pdf -l eng         # OCR in English
         wst ocr scan.pdf -l spa+eng     # OCR in Spanish and English
-        wst ocr scan.pdf --force        # Force OCR even if text exists
-        wst ocr scan.pdf --format json  # structured output
+        wst ocr 42 --format json        # structured output
     """
     from wst.ocr import ocr_files as run_ocr_batch
 
+    config: WstConfig = ctx.obj["config"]
     fmt: str = ctx.obj.get("format", "human")
 
-    if path.is_file():
-        if path.suffix.lower() != ".pdf":
+    files: list[Path] = []
+    db: Database | None = None
+    candidate = Path(target)
+    is_filesystem_target = candidate.exists()
+
+    if not is_filesystem_target:
+        # Treat as document identifier (ID or title).
+        db = Database(config.db_path)
+        try:
+            entry = _find_entry(db, target)
+            if entry is None:
+                if fmt == "human":
+                    click.echo(f"Document not found: {target}")
+                    raise SystemExit(1)
+                from wst.output import WstError
+
+                raise WstError("not_found", f"Document not found: {target}", exit_code=1)
+            doc_path = config.library_path / entry.file_path
+            if not doc_path.exists():
+                if fmt == "human":
+                    click.echo(f"File not found on disk: {doc_path}")
+                    raise SystemExit(1)
+                from wst.output import WstError
+
+                raise WstError(
+                    "not_found",
+                    f"File not found on disk: {doc_path}",
+                    exit_code=1,
+                )
+            if doc_path.suffix.lower() != ".pdf":
+                if fmt == "human":
+                    click.echo("Only PDF files can be OCR'd.")
+                    return
+                from wst.output import WstError
+
+                raise WstError("usage_error", "Only PDF files can be OCR'd.", exit_code=2)
+            files = [doc_path]
+        finally:
+            if db is not None:
+                db.close()
+    elif candidate.is_file():
+        if candidate.suffix.lower() != ".pdf":
             click.echo("Only PDF files can be OCR'd.")
             return
-        files = [path]
-    elif path.is_dir():
-        files = sorted(p for p in path.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf")
+        files = [candidate]
+    elif candidate.is_dir():
+        files = sorted(
+            p for p in candidate.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf"
+        )
         if not files:
             click.echo("No PDF files found in the given directory.")
             return
     else:
-        click.echo("Path must be a file or directory.")
+        click.echo("Target must be an ID, title, file, or directory.")
         return
 
     summary = run_ocr_batch(
@@ -2127,6 +2175,12 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
     config: WstConfig = ctx.obj["config"]
     fmt: str = ctx.obj.get("format", "human")
     db = Database(config.db_path)
+    is_ndjson = fmt == "ndjson"
+
+    def _emit_event(event: dict) -> None:
+        """Emit one NDJSON event to stdout, flushed."""
+        click.echo(json.dumps(event), nl=True)
+        sys.stdout.flush()
 
     try:
         from wst.topics import (
@@ -2163,12 +2217,16 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
             click.echo(f"\r          Backfilling content previews {current}/{total}...", nl=False)
 
         on_progress = _emit_backfill_progress if fmt == "human" else None
+        if is_ndjson:
+            _emit_event({"event": "phase", "name": "backfill_previews"})
         backfilled = backfill_content_previews(db, config.library_path, on_progress=on_progress)
         if fmt == "human" and backfilled:
             click.echo(f"\r          Backfilled content previews for {backfilled} documents.   ")
 
         if fmt == "human":
             click.echo("Step 1/4  Embedding documents and clustering...")
+        if is_ndjson:
+            _emit_event({"event": "phase", "name": "embedding"})
         # Pass existing vocab size as minimum so adding a few new documents
         # doesn't collapse the vocabulary to a smaller number of topics.
         min_topics = len(existing) if existing else None
@@ -2210,11 +2268,32 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
 
         if fmt == "human":
             click.echo("Step 2/4  Assigning topics to documents...")
+        if is_ndjson:
+            _emit_event(
+                {
+                    "event": "phase",
+                    "name": "assigning",
+                    "vocabulary": vocabulary,
+                }
+            )
 
-        assignments = assign_topics(db, ai, vocabulary)
+        def _on_doc(index: int, total: int, doc_id: int, topics: list[str]) -> None:
+            _emit_event(
+                {
+                    "event": "doc",
+                    "index": index,
+                    "total": total,
+                    "id": doc_id,
+                    "topics": topics,
+                }
+            )
+
+        assignments = assign_topics(db, ai, vocabulary, on_progress=_on_doc if is_ndjson else None)
 
         if fmt == "human":
             click.echo("Step 3/4  Saving to database...")
+        if is_ndjson:
+            _emit_event({"event": "phase", "name": "saving"})
 
         save_vocabulary(db, vocabulary, topic_to_subject)
 
@@ -2231,12 +2310,26 @@ def topics_build(ctx: click.Context, n_topics: int | None, yes: bool) -> None:
         # Backfill subjects from topic→subject mapping
         if fmt == "human":
             click.echo("Step 4/4  Backfilling subjects from topic clusters...")
+        if is_ndjson:
+            _emit_event({"event": "phase", "name": "subjects"})
         subject_updated = backfill_subjects(db, topic_to_subject)
 
         if fmt == "human":
             click.echo(f"\nDone. {len(assignments)} document(s) assigned topics.")
             click.echo(f"      {subject_updated} document(s) had their subject updated.")
             click.echo(f"Vocabulary ({len(vocabulary)}): {', '.join(vocabulary)}")
+            return
+
+        if is_ndjson:
+            _emit_event(
+                {
+                    "event": "done",
+                    "vocabulary": vocabulary,
+                    "subjects": topic_to_subject,
+                    "assigned_count": len(assignments),
+                    "subjects_updated": subject_updated,
+                }
+            )
             return
 
         from wst.output import render_ok

--- a/src/wst/topics.py
+++ b/src/wst/topics.py
@@ -515,15 +515,21 @@ def assign_topics(
     db: Database,
     ai_backend: AIBackend,
     vocabulary: list[str],
+    on_progress: Callable[[int, int, int, list[str]], None] | None = None,
 ) -> dict[int, list[str]]:
     """Assign 1-3 topics from vocabulary to every document.
+
+    on_progress, if provided, is invoked once per document with
+    `(index, total, doc_id, topics)` so callers (e.g. the CLI in NDJSON
+    mode) can stream per-document progress.
 
     Returns {doc_id: [topic1, topic2, ...]}
     """
     entries = db.list_all()
+    total = len(entries)
     assignments: dict[int, list[str]] = {}
 
-    for entry in entries:
+    for index, entry in enumerate(entries, 1):
         m = entry.metadata
         doc = {
             "title": m.title,
@@ -536,6 +542,8 @@ def assign_topics(
         raw = _call_ai_raw(ai_backend, prompt)
         topics = _parse_json_list(raw, vocabulary)
         assignments[entry.id] = topics  # type: ignore[assignment]
+        if on_progress is not None:
+            on_progress(index, total, entry.id, topics)  # type: ignore[arg-type]
 
     return assignments
 


### PR DESCRIPTION
Closes #39

This PR contains RFC 0016 proposing to bring `wst ocr` and `wst topics build` into the desktop app, mirroring the RFC 0013 ingest-from-GUI pattern (CLI subprocess + NDJSON streaming via `run_wst_command`).

**The problem**: today the GUI exposes ingest, list/search/edit, and Backup. OCR (per-document, scanned PDFs) and topic modeling (library-wide) are still CLI-only — that's exactly what #39 asks to fix.

**The proposal**:
- **OCR**: per-doc button in `BookDetail`, shells out to `wst ocr <id> --format ndjson` (one-shot, returns final result).
- **Topics**: a `TopicsPane` in the sidebar (parallel to `BackupPane`), shells out to `wst topics build --yes --format ndjson` and streams `phase`/`doc`/`done` events into a progress modal. Both CLI commands gain a new `--format ndjson` mode (small extension).

## What's in this PR (RFC phase)

- `docs/rfcs/0016-gui-ocr-topics.md` — design with NDJSON event shapes, UI placement, and confirmation/refresh flows.

## Open questions

Five questions in the RFC (Q1–Q5) — sidebar vs Extras pane placement, streaming-vs-one-shot for OCR, confirmation/advanced options for topics, post-build refresh strategy, and whether to add a "needs OCR" doc indicator.

**To approve:** add the `approved` label to issue #39.
**To request changes:** comment on this PR or the issue.